### PR TITLE
GCI: Rename public functions in src/dynext.c

### DIFF
--- a/compilers/imcc/imcc.y
+++ b/compilers/imcc/imcc.y
@@ -970,7 +970,7 @@ do_loadlib(PARROT_INTERP, ARGIN(const char *lib))
 {
     ASSERT_ARGS(do_loadlib)
     STRING * const s       = Parrot_str_unescape(interp, lib + 1, '"', NULL);
-    PMC    * const lib_pmc = Parrot_load_lib(interp, s, NULL);
+    PMC    * const lib_pmc = Parrot_dyn_load_lib(interp, s, NULL);
     if (PMC_IS_NULL(lib_pmc) || !VTABLE_get_bool(interp, lib_pmc)) {
         IMCC_fataly(interp, EXCEPTION_LIBRARY_ERROR,
             "loadlib directive could not find library `%S'", s);

--- a/compilers/imcc/imcparser.c
+++ b/compilers/imcc/imcparser.c
@@ -1051,7 +1051,7 @@ do_loadlib(PARROT_INTERP, ARGIN(const char *lib))
 {
     ASSERT_ARGS(do_loadlib)
     STRING * const s       = Parrot_str_unescape(interp, lib + 1, '"', NULL);
-    PMC    * const lib_pmc = Parrot_load_lib(interp, s, NULL);
+    PMC    * const lib_pmc = Parrot_dyn_load_lib(interp, s, NULL);
     if (PMC_IS_NULL(lib_pmc) || !VTABLE_get_bool(interp, lib_pmc)) {
         IMCC_fataly(interp, EXCEPTION_LIBRARY_ERROR,
             "loadlib directive could not find library `%S'", s);

--- a/docs/embed.pod
+++ b/docs/embed.pod
@@ -850,7 +850,7 @@ The list may also be augmented if additional functionality is required.
 
 =item C<Parrot_load_language>
 
-=item C<Parrot_load_lib>
+=item C<Parrot_dyn_load_lib>
 
 =item C<Parrot_locate_runtime_file>
 

--- a/include/parrot/dynext.h
+++ b/include/parrot/dynext.h
@@ -20,7 +20,7 @@ typedef void (*dynext_init_func)(PARROT_INTERP, ARGIN_NULLOK(PMC *));
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 PARROT_CANNOT_RETURN_NULL
-PMC * Parrot_clone_lib_into(
+PMC * Parrot_dyn_clone_lib_into(
     ARGMOD(Interp *d),
     ARGMOD(Interp *s),
     ARGIN(PMC *lib_pmc))
@@ -32,14 +32,14 @@ PMC * Parrot_clone_lib_into(
 
 PARROT_EXPORT
 PARROT_CAN_RETURN_NULL
-void * Parrot_dlsym_str(PARROT_INTERP,
+void * Parrot_dyn_dlsym_str(PARROT_INTERP,
     ARGIN_NULLOK(void *handle),
     ARGIN_NULLOK(STRING *symbol))
         __attribute__nonnull__(1);
 
 PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
-PMC * Parrot_init_lib(PARROT_INTERP,
+PMC * Parrot_dyn_init_lib(PARROT_INTERP,
     NULLOK(dynext_load_func load_func),
     NULLOK(dynext_init_func init_func))
         __attribute__nonnull__(1);
@@ -47,20 +47,20 @@ PMC * Parrot_init_lib(PARROT_INTERP,
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 PARROT_CANNOT_RETURN_NULL
-PMC * Parrot_load_lib(PARROT_INTERP,
+PMC * Parrot_dyn_load_lib(PARROT_INTERP,
     ARGIN_NULLOK(STRING *lib),
     ARGIN_NULLOK(PMC *parameters))
         __attribute__nonnull__(1);
 
-#define ASSERT_ARGS_Parrot_clone_lib_into __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_dyn_clone_lib_into __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(d) \
     , PARROT_ASSERT_ARG(s) \
     , PARROT_ASSERT_ARG(lib_pmc))
-#define ASSERT_ARGS_Parrot_dlsym_str __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_dyn_dlsym_str __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp))
-#define ASSERT_ARGS_Parrot_init_lib __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_dyn_init_lib __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp))
-#define ASSERT_ARGS_Parrot_load_lib __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_dyn_load_lib __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp))
 /* Don't modify between HEADERIZER BEGIN / HEADERIZER END.  Your changes will be lost. */
 /* HEADERIZER END: src/dynext.c */

--- a/src/dynext.c
+++ b/src/dynext.c
@@ -392,7 +392,7 @@ get_path(PARROT_INTERP, ARGMOD(STRING *lib), Parrot_dlopen_flags flags,
 
 /*
 
-=item C<PMC * Parrot_init_lib(PARROT_INTERP, dynext_load_func load_func,
+=item C<PMC * Parrot_dyn_init_lib(PARROT_INTERP, dynext_load_func load_func,
 dynext_init_func init_func)>
 
 Initializes a new library. First, calls C<load_func> to load the library
@@ -406,11 +406,11 @@ ParrotLibrary PMC object that represents the initialized library.
 PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
 PMC *
-Parrot_init_lib(PARROT_INTERP,
+Parrot_dyn_init_lib(PARROT_INTERP,
         NULLOK(dynext_load_func load_func),
         NULLOK(dynext_init_func init_func))
 {
-    ASSERT_ARGS(Parrot_init_lib)
+    ASSERT_ARGS(Parrot_dyn_init_lib)
     PMC *lib_pmc = NULL;
 
     if (load_func)
@@ -430,7 +430,8 @@ Parrot_init_lib(PARROT_INTERP,
 
 /*
 
-=item C<void * Parrot_dlsym_str(PARROT_INTERP, void *handle, STRING *symbol)>
+=item C<void * Parrot_dyn_dlsym_str(PARROT_INTERP, void *handle, STRING
+*symbol)>
 
 Loads a symbol named C<symbol> from the shared library represented by
 C<handle>.
@@ -442,10 +443,10 @@ C<handle>.
 PARROT_EXPORT
 PARROT_CAN_RETURN_NULL
 void *
-Parrot_dlsym_str(PARROT_INTERP,
+Parrot_dyn_dlsym_str(PARROT_INTERP,
         ARGIN_NULLOK(void *handle), ARGIN_NULLOK(STRING *symbol))
 {
-    ASSERT_ARGS(Parrot_dlsym_str)
+    ASSERT_ARGS(Parrot_dyn_dlsym_str)
 
     if (STRING_IS_NULL(symbol))
         return NULL;
@@ -497,11 +498,11 @@ run_init_lib(PARROT_INTERP, ARGIN(void *handle),
                                         "Parrot_lib_%Ss_init", lib_name);
 
         /* get load_func */
-        void * dlsymfunc = Parrot_dlsym_str(interp, handle, load_name);
+        void * dlsymfunc = Parrot_dyn_dlsym_str(interp, handle, load_name);
         load_func = (PMC * (*)(PARROT_INTERP)) D2FPTR(dlsymfunc);
 
         /* get init_func */
-        dlsymfunc = Parrot_dlsym_str(interp, handle, init_func_name);
+        dlsymfunc = Parrot_dyn_dlsym_str(interp, handle, init_func_name);
         init_func = (void (*)(PARROT_INTERP, PMC *)) D2FPTR(dlsymfunc);
     }
     else {
@@ -509,7 +510,7 @@ run_init_lib(PARROT_INTERP, ARGIN(void *handle),
         init_func = NULL;
     }
 
-    lib_pmc = Parrot_init_lib(interp, load_func, init_func);
+    lib_pmc = Parrot_dyn_init_lib(interp, load_func, init_func);
     VTABLE_set_pointer(interp, lib_pmc, handle);
 
     if (!load_func)
@@ -583,7 +584,7 @@ make_string_pmc(PARROT_INTERP, ARGIN(STRING *string))
 
 /*
 
-=item C<PMC * Parrot_clone_lib_into(Interp *d, Interp *s, PMC *lib_pmc)>
+=item C<PMC * Parrot_dyn_clone_lib_into(Interp *d, Interp *s, PMC *lib_pmc)>
 
 Clones a ParrotLibrary PMC C<lib_pmc> from interpreter C<s> into interpreter
 C<d>.
@@ -596,9 +597,9 @@ PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 PARROT_CANNOT_RETURN_NULL
 PMC *
-Parrot_clone_lib_into(ARGMOD(Interp *d), ARGMOD(Interp *s), ARGIN(PMC *lib_pmc))
+Parrot_dyn_clone_lib_into(ARGMOD(Interp *d), ARGMOD(Interp *s), ARGIN(PMC *lib_pmc))
 {
-    ASSERT_ARGS(Parrot_clone_lib_into)
+    ASSERT_ARGS(Parrot_dyn_clone_lib_into)
     STRING * const filename = CONST_STRING(s, "_filename");
     STRING * const libname  = CONST_STRING(s, "_lib_name");
     STRING * const type_str = CONST_STRING(s, "_type");
@@ -652,7 +653,7 @@ Parrot_clone_lib_into(ARGMOD(Interp *d), ARGMOD(Interp *s), ARGIN(PMC *lib_pmc))
 
 /*
 
-=item C<PMC * Parrot_load_lib(PARROT_INTERP, STRING *lib, PMC *parameters)>
+=item C<PMC * Parrot_dyn_load_lib(PARROT_INTERP, STRING *lib, PMC *parameters)>
 
 Dynamic library loader.
 
@@ -681,9 +682,9 @@ PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 PARROT_CANNOT_RETURN_NULL
 PMC *
-Parrot_load_lib(PARROT_INTERP, ARGIN_NULLOK(STRING *lib), ARGIN_NULLOK(PMC *parameters))
+Parrot_dyn_load_lib(PARROT_INTERP, ARGIN_NULLOK(STRING *lib), ARGIN_NULLOK(PMC *parameters))
 {
-    ASSERT_ARGS(Parrot_load_lib)
+    ASSERT_ARGS(Parrot_dyn_load_lib)
     void   *handle;
     PMC    *lib_pmc;
     STRING *path;

--- a/src/ops/core.ops
+++ b/src/ops/core.ops
@@ -1248,11 +1248,11 @@ the callback function.
 =cut
 
 inline op loadlib(out PMC, in STR) {
-    $1 = Parrot_load_lib(interp, $2, NULL);
+    $1 = Parrot_dyn_load_lib(interp, $2, NULL);
 }
 
 inline op loadlib(out PMC, in STR, in PMC) {
-    $1 = Parrot_load_lib(interp, $2, $3);
+    $1 = Parrot_dyn_load_lib(interp, $2, $3);
 }
 
 op dlfunc(out PMC, invar PMC, in STR, in STR) {
@@ -1266,7 +1266,7 @@ op dlfunc(out PMC, invar PMC, in STR, in STR) {
         dl_handle = ((Parrot_ParrotLibrary_attributes*)PMC_data($2))->dl_handle;
     }
 
-    ptr = Parrot_dlsym_str(interp, dl_handle, $3);
+    ptr = Parrot_dyn_dlsym_str(interp, dl_handle, $3);
     p = D2FPTR(ptr);
 
     if (p == NULLfunc) {
@@ -1291,7 +1291,7 @@ op dlvar(out PMC, invar PMC, in STR) {
         dl_handle = ((Parrot_ParrotLibrary_attributes*)PMC_data($2))->dl_handle;
     }
 
-    p = Parrot_dlsym_str(interp, dl_handle, $3);
+    p = Parrot_dyn_dlsym_str(interp, dl_handle, $3);
 
     if (p == NULL) {
         const char * const err = Parrot_dlerror();

--- a/src/ops/core_ops.c
+++ b/src/ops/core_ops.c
@@ -16033,42 +16033,42 @@ return (opcode_t *)cur_opcode + 2;}
 opcode_t *
 Parrot_loadlib_p_s(opcode_t *cur_opcode, PARROT_INTERP)  {
     const Parrot_Context * const CUR_CTX = Parrot_pcc_get_context_struct(interp, interp->ctx);
-    PREG(1) = Parrot_load_lib(interp, SREG(2), NULL);
+    PREG(1) = Parrot_dyn_load_lib(interp, SREG(2), NULL);
 
 return (opcode_t *)cur_opcode + 3;}
 
 opcode_t *
 Parrot_loadlib_p_sc(opcode_t *cur_opcode, PARROT_INTERP)  {
     const Parrot_Context * const CUR_CTX = Parrot_pcc_get_context_struct(interp, interp->ctx);
-    PREG(1) = Parrot_load_lib(interp, SCONST(2), NULL);
+    PREG(1) = Parrot_dyn_load_lib(interp, SCONST(2), NULL);
 
 return (opcode_t *)cur_opcode + 3;}
 
 opcode_t *
 Parrot_loadlib_p_s_p(opcode_t *cur_opcode, PARROT_INTERP)  {
     const Parrot_Context * const CUR_CTX = Parrot_pcc_get_context_struct(interp, interp->ctx);
-    PREG(1) = Parrot_load_lib(interp, SREG(2), PREG(3));
+    PREG(1) = Parrot_dyn_load_lib(interp, SREG(2), PREG(3));
 
 return (opcode_t *)cur_opcode + 4;}
 
 opcode_t *
 Parrot_loadlib_p_sc_p(opcode_t *cur_opcode, PARROT_INTERP)  {
     const Parrot_Context * const CUR_CTX = Parrot_pcc_get_context_struct(interp, interp->ctx);
-    PREG(1) = Parrot_load_lib(interp, SCONST(2), PREG(3));
+    PREG(1) = Parrot_dyn_load_lib(interp, SCONST(2), PREG(3));
 
 return (opcode_t *)cur_opcode + 4;}
 
 opcode_t *
 Parrot_loadlib_p_s_pc(opcode_t *cur_opcode, PARROT_INTERP)  {
     const Parrot_Context * const CUR_CTX = Parrot_pcc_get_context_struct(interp, interp->ctx);
-    PREG(1) = Parrot_load_lib(interp, SREG(2), PCONST(3));
+    PREG(1) = Parrot_dyn_load_lib(interp, SREG(2), PCONST(3));
 
 return (opcode_t *)cur_opcode + 4;}
 
 opcode_t *
 Parrot_loadlib_p_sc_pc(opcode_t *cur_opcode, PARROT_INTERP)  {
     const Parrot_Context * const CUR_CTX = Parrot_pcc_get_context_struct(interp, interp->ctx);
-    PREG(1) = Parrot_load_lib(interp, SCONST(2), PCONST(3));
+    PREG(1) = Parrot_dyn_load_lib(interp, SCONST(2), PCONST(3));
 
 return (opcode_t *)cur_opcode + 4;}
 
@@ -16085,7 +16085,7 @@ Parrot_dlfunc_p_p_s_s(opcode_t *cur_opcode, PARROT_INTERP)  {
         dl_handle = ((Parrot_ParrotLibrary_attributes*)PMC_data(PREG(2)))->dl_handle;
     }
 
-    ptr = Parrot_dlsym_str(interp, dl_handle, SREG(3));
+    ptr = Parrot_dyn_dlsym_str(interp, dl_handle, SREG(3));
     p = D2FPTR(ptr);
 
     if (p == NULLfunc) {
@@ -16114,7 +16114,7 @@ Parrot_dlfunc_p_p_sc_s(opcode_t *cur_opcode, PARROT_INTERP)  {
         dl_handle = ((Parrot_ParrotLibrary_attributes*)PMC_data(PREG(2)))->dl_handle;
     }
 
-    ptr = Parrot_dlsym_str(interp, dl_handle, SCONST(3));
+    ptr = Parrot_dyn_dlsym_str(interp, dl_handle, SCONST(3));
     p = D2FPTR(ptr);
 
     if (p == NULLfunc) {
@@ -16143,7 +16143,7 @@ Parrot_dlfunc_p_p_s_sc(opcode_t *cur_opcode, PARROT_INTERP)  {
         dl_handle = ((Parrot_ParrotLibrary_attributes*)PMC_data(PREG(2)))->dl_handle;
     }
 
-    ptr = Parrot_dlsym_str(interp, dl_handle, SREG(3));
+    ptr = Parrot_dyn_dlsym_str(interp, dl_handle, SREG(3));
     p = D2FPTR(ptr);
 
     if (p == NULLfunc) {
@@ -16172,7 +16172,7 @@ Parrot_dlfunc_p_p_sc_sc(opcode_t *cur_opcode, PARROT_INTERP)  {
         dl_handle = ((Parrot_ParrotLibrary_attributes*)PMC_data(PREG(2)))->dl_handle;
     }
 
-    ptr = Parrot_dlsym_str(interp, dl_handle, SCONST(3));
+    ptr = Parrot_dyn_dlsym_str(interp, dl_handle, SCONST(3));
     p = D2FPTR(ptr);
 
     if (p == NULLfunc) {
@@ -16200,7 +16200,7 @@ Parrot_dlvar_p_p_s(opcode_t *cur_opcode, PARROT_INTERP)  {
         dl_handle = ((Parrot_ParrotLibrary_attributes*)PMC_data(PREG(2)))->dl_handle;
     }
 
-    p = Parrot_dlsym_str(interp, dl_handle, SREG(3));
+    p = Parrot_dyn_dlsym_str(interp, dl_handle, SREG(3));
 
     if (p == NULL) {
         const char * const err = Parrot_dlerror();
@@ -16229,7 +16229,7 @@ Parrot_dlvar_p_p_sc(opcode_t *cur_opcode, PARROT_INTERP)  {
         dl_handle = ((Parrot_ParrotLibrary_attributes*)PMC_data(PREG(2)))->dl_handle;
     }
 
-    p = Parrot_dlsym_str(interp, dl_handle, SCONST(3));
+    p = Parrot_dyn_dlsym_str(interp, dl_handle, SCONST(3));
 
     if (p == NULL) {
         const char * const err = Parrot_dlerror();

--- a/src/packfile.c
+++ b/src/packfile.c
@@ -2714,7 +2714,7 @@ byte_code_unpack(PARROT_INTERP, ARGMOD(PackFile_Segment *self), ARGIN(const opco
 
     for (i = 0; i < byte_code->n_libdeps; i++) {
         STRING *libname = PF_fetch_string(interp, self->pf, &cursor);
-        PMC    *lib_pmc = Parrot_load_lib(interp, libname, NULL);
+        PMC    *lib_pmc = Parrot_dyn_load_lib(interp, libname, NULL);
     }
 
     for (i = 0; i < byte_code->op_mapping.n_libs; i++) {
@@ -2734,7 +2734,7 @@ byte_code_unpack(PARROT_INTERP, ARGMOD(PackFile_Segment *self), ARGIN(const opco
                 entry->lib = PARROT_CORE_OPLIB_INIT(interp, 1);
             }
             else {
-                PMC *lib_pmc = Parrot_load_lib(interp,
+                PMC *lib_pmc = Parrot_dyn_load_lib(interp,
                                                 Parrot_str_new(interp, lib_name, 0),
                                                 NULL);
                 typedef op_lib_t *(*oplib_init_t)(PARROT_INTERP, long init);

--- a/src/pmc/parrotinterpreter.pmc
+++ b/src/pmc/parrotinterpreter.pmc
@@ -126,7 +126,7 @@ clone_interpreter(Parrot_Interp d, Parrot_Interp s, INTVAL flags)
         for (i = 0; i < n; ++i) {
             STRING * const key     = VTABLE_shift_string(s, lib_iter);
             PMC    * const lib_pmc = VTABLE_get_pmc_keyed_str(s, libs, key);
-            PMC    * const ignored = Parrot_clone_lib_into(d, s, lib_pmc);
+            PMC    * const ignored = Parrot_dyn_clone_lib_into(d, s, lib_pmc);
             UNUSED(ignored);
         }
     }

--- a/t/tools/dev/searchops/samples.pm
+++ b/t/tools/dev/searchops/samples.pm
@@ -115,7 +115,7 @@ Load a dynamic link library named $2 and store it in $1.
 =cut
 
 inline op loadlib(out PMC, in STR) {
-    $1 = Parrot_load_lib(interp, $2, NULL);
+    $1 = Parrot_dyn_load_lib(interp, $2, NULL);
 }
 
 =back


### PR DESCRIPTION
`make headerizer` was run and `make test` passes without any errors. 

task: http://www.google-melange.com/gci/task/show/google/gci2010/parrot_perl_foundations/t129035436897
