### PR TITLE
GCI: Rename public functions in src/vtable.c

### DIFF
--- a/include/parrot/vtables.h
+++ b/include/parrot/vtables.h
@@ -14,54 +14,55 @@
 PARROT_EXPORT
 PARROT_MALLOC
 PARROT_CANNOT_RETURN_NULL
-VTABLE * Parrot_clone_vtable(PARROT_INTERP,
+VTABLE * Parrot_vtbl_clone_vtable(PARROT_INTERP,
     ARGIN(const VTABLE *base_vtable))
         __attribute__nonnull__(1)
         __attribute__nonnull__(2);
 
 PARROT_EXPORT
-void Parrot_destroy_vtable(PARROT_INTERP, ARGFREE_NOTNULL(VTABLE *vtable))
+void Parrot_vtbl_destroy_vtable(PARROT_INTERP,
+    ARGFREE_NOTNULL(VTABLE *vtable))
         __attribute__nonnull__(1)
         __attribute__nonnull__(2);
 
 PARROT_EXPORT
-void Parrot_initialize_core_vtables(PARROT_INTERP)
+void Parrot_vtbl_initialize_core_vtables(PARROT_INTERP)
         __attribute__nonnull__(1);
 
 PARROT_EXPORT
 PARROT_MALLOC
 PARROT_CANNOT_RETURN_NULL
-VTABLE * Parrot_new_vtable(SHIM_INTERP);
+VTABLE * Parrot_vtbl_new_vtable(SHIM_INTERP);
 
-void mark_vtables(PARROT_INTERP)
+void Parrot_vtbl_alloc_vtables(PARROT_INTERP)
         __attribute__nonnull__(1);
 
-void parrot_alloc_vtables(PARROT_INTERP)
+void Parrot_vtbl_free_vtables(PARROT_INTERP)
         __attribute__nonnull__(1);
 
-void parrot_free_vtables(PARROT_INTERP)
+void Parrot_vtbl_mark_vtables(PARROT_INTERP)
         __attribute__nonnull__(1);
 
-void parrot_realloc_vtables(PARROT_INTERP)
+void Parrot_vtbl_realloc_vtables(PARROT_INTERP)
         __attribute__nonnull__(1);
 
-#define ASSERT_ARGS_Parrot_clone_vtable __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_vtbl_clone_vtable __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(base_vtable))
-#define ASSERT_ARGS_Parrot_destroy_vtable __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_vtbl_destroy_vtable __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(vtable))
-#define ASSERT_ARGS_Parrot_initialize_core_vtables \
+#define ASSERT_ARGS_Parrot_vtbl_initialize_core_vtables \
      __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp))
-#define ASSERT_ARGS_Parrot_new_vtable __attribute__unused__ int _ASSERT_ARGS_CHECK = (0)
-#define ASSERT_ARGS_mark_vtables __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_vtbl_new_vtable __attribute__unused__ int _ASSERT_ARGS_CHECK = (0)
+#define ASSERT_ARGS_Parrot_vtbl_alloc_vtables __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp))
-#define ASSERT_ARGS_parrot_alloc_vtables __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_vtbl_free_vtables __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp))
-#define ASSERT_ARGS_parrot_free_vtables __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_vtbl_mark_vtables __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp))
-#define ASSERT_ARGS_parrot_realloc_vtables __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_vtbl_realloc_vtables __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp))
 /* Don't modify between HEADERIZER BEGIN / HEADERIZER END.  Your changes will be lost. */
 /* HEADERIZER END: src/vtables.c */

--- a/lib/Parrot/Pmc2c/PMC/default.pm
+++ b/lib/Parrot/Pmc2c/PMC/default.pm
@@ -116,7 +116,7 @@ PARROT_EXPORT VTABLE* Parrot_default_get_vtable(PARROT_INTERP) {
 
 $vtable_decl
 
-    return Parrot_clone_vtable(interp, &temp_vtable);
+    return Parrot_vtbl_clone_vtable(interp, &temp_vtable);
 }
 
 EOC

--- a/src/gc/mark_sweep.c
+++ b/src/gc/mark_sweep.c
@@ -190,7 +190,7 @@ Parrot_gc_trace_root(PARROT_INTERP,
     Parrot_gc_mark_PMC_alive(interp, interp->dynamic_env);
 
     /* mark the vtables: the data, Class PMCs, etc. */
-    mark_vtables(interp);
+    Parrot_vtbl_mark_vtables(interp);
 
     /* mark the root_namespace */
     Parrot_gc_mark_PMC_alive(interp, interp->root_namespace);

--- a/src/interp/inter_create.c
+++ b/src/interp/inter_create.c
@@ -216,7 +216,7 @@ initialize_interpreter(PARROT_INTERP, ARGIN(void *stacktop))
     /* initialize classes - this needs mmd func table */
     interp->HLL_info = NULL;
 
-    Parrot_initialize_core_vtables(interp);
+    Parrot_vtbl_initialize_core_vtables(interp);
 
     /* create the root set registry */
     interp->gc_registry     = Parrot_pmc_new(interp, enum_class_AddrRegistry);
@@ -462,7 +462,7 @@ Parrot_really_destroy(PARROT_INTERP, SHIM(int exit_code), SHIM(void *arg))
             parrot_hash_destroy(interp, interp->op_hash);
 
         /* free vtables */
-        parrot_free_vtables(interp);
+        Parrot_vtbl_free_vtables(interp);
 
         /* Finalize GC */
         Parrot_gc_finalize(interp);
@@ -485,7 +485,7 @@ Parrot_really_destroy(PARROT_INTERP, SHIM(int exit_code), SHIM(void *arg))
                 interp->thread_data = NULL;
             }
 
-            parrot_free_vtables(interp);
+            Parrot_vtbl_free_vtables(interp);
 
             /* Finalyze GC */
             Parrot_gc_finalize(interp);

--- a/src/pmc.c
+++ b/src/pmc.c
@@ -712,7 +712,7 @@ Parrot_pmc_get_new_vtable_index(PARROT_INTERP)
 
     /* Have we overflowed the table? */
     if (type_id >= interp->n_vtable_alloced)
-        parrot_realloc_vtables(interp);
+        Parrot_vtbl_realloc_vtables(interp);
 
     return type_id;
 }

--- a/src/pmc/class.pmc
+++ b/src/pmc/class.pmc
@@ -335,14 +335,14 @@ init_class_from_hash(PARROT_INTERP, ARGMOD(PMC *self), ARGIN_NULLOK(PMC *info))
         type_num   = Parrot_oo_register_type(interp, name_arg, new_namespace);
 
         /* Link the type number with the class's vtable. */
-        new_vtable = Parrot_clone_vtable(interp, self->vtable);
+        new_vtable = Parrot_vtbl_clone_vtable(interp, self->vtable);
 
         new_vtable->base_type         = type_num;
         new_vtable->pmc_class         = self;
         new_vtable->whoami            = VTABLE_get_string(interp, self);
         new_vtable->mro               = _class->all_parents;
         new_vtable->ro_variant_vtable =
-                Parrot_clone_vtable(interp, self->vtable->ro_variant_vtable);
+                Parrot_vtbl_clone_vtable(interp, self->vtable->ro_variant_vtable);
 
         /* Store the class's vtable in the global table */
         interp->vtables[type_num]     = new_vtable;

--- a/src/pmc/parrotinterpreter.pmc
+++ b/src/pmc/parrotinterpreter.pmc
@@ -94,7 +94,7 @@ clone_interpreter(Parrot_Interp d, Parrot_Interp s, INTVAL flags)
         d->n_vtable_max = s->n_vtable_max;
 
         if (d->n_vtable_max > d->n_vtable_alloced)
-            parrot_realloc_vtables(d);
+            Parrot_vtbl_realloc_vtables(d);
 
         last_remove = s->n_vtable_max;
 

--- a/src/vtables.c
+++ b/src/vtables.c
@@ -27,7 +27,7 @@ extern void Parrot_initialize_core_pmcs(PARROT_INTERP, int pass);
 
 /*
 
-=item C<VTABLE * Parrot_new_vtable(PARROT_INTERP)>
+=item C<VTABLE * Parrot_vtbl_new_vtable(PARROT_INTERP)>
 
 Creates and returns a pointer to the new C<VTABLE>.
 
@@ -39,15 +39,16 @@ PARROT_EXPORT
 PARROT_MALLOC
 PARROT_CANNOT_RETURN_NULL
 VTABLE *
-Parrot_new_vtable(SHIM_INTERP)
+Parrot_vtbl_new_vtable(SHIM_INTERP)
 {
-    ASSERT_ARGS(Parrot_new_vtable)
+    ASSERT_ARGS(Parrot_vtbl_new_vtable)
     return mem_internal_allocate_zeroed_typed(VTABLE);
 }
 
 /*
 
-=item C<VTABLE * Parrot_clone_vtable(PARROT_INTERP, const VTABLE *base_vtable)>
+=item C<VTABLE * Parrot_vtbl_clone_vtable(PARROT_INTERP, const VTABLE
+*base_vtable)>
 
 Clones C<*base_vtable> and returns a pointer to the new C<VTABLE>.
 
@@ -59,9 +60,9 @@ PARROT_EXPORT
 PARROT_MALLOC
 PARROT_CANNOT_RETURN_NULL
 VTABLE *
-Parrot_clone_vtable(PARROT_INTERP, ARGIN(const VTABLE *base_vtable))
+Parrot_vtbl_clone_vtable(PARROT_INTERP, ARGIN(const VTABLE *base_vtable))
 {
-    ASSERT_ARGS(Parrot_clone_vtable)
+    ASSERT_ARGS(Parrot_vtbl_clone_vtable)
     VTABLE * const new_vtable = mem_internal_allocate_typed(VTABLE);
 
     STRUCT_COPY(new_vtable, base_vtable);
@@ -80,7 +81,7 @@ Parrot_clone_vtable(PARROT_INTERP, ARGIN(const VTABLE *base_vtable))
 
 /*
 
-=item C<void Parrot_destroy_vtable(PARROT_INTERP, VTABLE *vtable)>
+=item C<void Parrot_vtbl_destroy_vtable(PARROT_INTERP, VTABLE *vtable)>
 
 Destroys C<*vtable>.
 
@@ -90,9 +91,9 @@ Destroys C<*vtable>.
 
 PARROT_EXPORT
 void
-Parrot_destroy_vtable(PARROT_INTERP, ARGFREE_NOTNULL(VTABLE *vtable))
+Parrot_vtbl_destroy_vtable(PARROT_INTERP, ARGFREE_NOTNULL(VTABLE *vtable))
 {
-    ASSERT_ARGS(Parrot_destroy_vtable)
+    ASSERT_ARGS(Parrot_vtbl_destroy_vtable)
     /* We sometimes get a type number allocated without any corresponding
      * vtable. E.g. if you load perl_group, perlscalar is this way.  */
 
@@ -121,7 +122,7 @@ Parrot_destroy_vtable(PARROT_INTERP, ARGFREE_NOTNULL(VTABLE *vtable))
 
 /*
 
-=item C<void parrot_alloc_vtables(PARROT_INTERP)>
+=item C<void Parrot_vtbl_alloc_vtables(PARROT_INTERP)>
 
 Allocate memory for the vtables for all known classes (PMC types).
 
@@ -130,9 +131,9 @@ Allocate memory for the vtables for all known classes (PMC types).
 */
 
 void
-parrot_alloc_vtables(PARROT_INTERP)
+Parrot_vtbl_alloc_vtables(PARROT_INTERP)
 {
-    ASSERT_ARGS(parrot_alloc_vtables)
+    ASSERT_ARGS(Parrot_vtbl_alloc_vtables)
     interp->vtables          = mem_internal_allocate_n_zeroed_typed(PARROT_MAX_CLASSES, VTABLE *);
     interp->n_vtable_max     = enum_class_core_max;
     interp->n_vtable_alloced = PARROT_MAX_CLASSES - 1;
@@ -140,7 +141,7 @@ parrot_alloc_vtables(PARROT_INTERP)
 
 /*
 
-=item C<void parrot_realloc_vtables(PARROT_INTERP)>
+=item C<void Parrot_vtbl_realloc_vtables(PARROT_INTERP)>
 
 Reallocate memory for vtables, increasing the number of vtables by 16.
 
@@ -149,9 +150,9 @@ Reallocate memory for vtables, increasing the number of vtables by 16.
 */
 
 void
-parrot_realloc_vtables(PARROT_INTERP)
+Parrot_vtbl_realloc_vtables(PARROT_INTERP)
 {
-    ASSERT_ARGS(parrot_realloc_vtables)
+    ASSERT_ARGS(Parrot_vtbl_realloc_vtables)
     /* 16 bigger seems reasonable, though it's only a pointer
        table and we could get bigger without blowing much memory
        */
@@ -167,10 +168,10 @@ parrot_realloc_vtables(PARROT_INTERP)
 
 /*
 
-=item C<void parrot_free_vtables(PARROT_INTERP)>
+=item C<void Parrot_vtbl_free_vtables(PARROT_INTERP)>
 
 Free memory allocated for the vtables. Each vtable is destroyed
-through its destructor Parrot_destroy_vtable, after which the list
+through its destructor Parrot_vtbl_destroy_vtable, after which the list
 of pointers to these vtables is freed.
 
 =cut
@@ -178,20 +179,20 @@ of pointers to these vtables is freed.
 */
 
 void
-parrot_free_vtables(PARROT_INTERP)
+Parrot_vtbl_free_vtables(PARROT_INTERP)
 {
-    ASSERT_ARGS(parrot_free_vtables)
+    ASSERT_ARGS(Parrot_vtbl_free_vtables)
     int i;
 
     for (i = 0; i < interp->n_vtable_max; ++i)
-        Parrot_destroy_vtable(interp, interp->vtables[i]);
+        Parrot_vtbl_destroy_vtable(interp, interp->vtables[i]);
 
     mem_internal_free(interp->vtables);
 }
 
 /*
 
-=item C<void mark_vtables(PARROT_INTERP)>
+=item C<void Parrot_vtbl_mark_vtables(PARROT_INTERP)>
 
 Mark all vtables as being alive for the garbage collector.
 
@@ -200,9 +201,9 @@ Mark all vtables as being alive for the garbage collector.
 */
 
 void
-mark_vtables(PARROT_INTERP)
+Parrot_vtbl_mark_vtables(PARROT_INTERP)
 {
-    ASSERT_ARGS(mark_vtables)
+    ASSERT_ARGS(Parrot_vtbl_mark_vtables)
     INTVAL i;
 
     for (i = 1; i < interp->n_vtable_max; ++i) {
@@ -222,7 +223,7 @@ mark_vtables(PARROT_INTERP)
 
 /*
 
-=item C<void Parrot_initialize_core_vtables(PARROT_INTERP)>
+=item C<void Parrot_vtbl_initialize_core_vtables(PARROT_INTERP)>
 
 Initialize vtables for the core PMCs.
 
@@ -232,12 +233,12 @@ Initialize vtables for the core PMCs.
 
 PARROT_EXPORT
 void
-Parrot_initialize_core_vtables(PARROT_INTERP)
+Parrot_vtbl_initialize_core_vtables(PARROT_INTERP)
 {
-    ASSERT_ARGS(Parrot_initialize_core_vtables)
+    ASSERT_ARGS(Parrot_vtbl_initialize_core_vtables)
 
     if (! interp->vtables) {
-        parrot_alloc_vtables(interp);
+        Parrot_vtbl_alloc_vtables(interp);
         Parrot_initialize_core_pmcs(interp, 0);
     }
 }


### PR DESCRIPTION
`make headerizer` was run and `make test` passes without errors.

task: http://www.google-melange.com/gci/task/show/google/gci2010/parrot_perl_foundations/t129033244420#c1001

Thanks for mentoring these tasks.
