### PR TITLE
GCI: Rename public functions in src/utils.c

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -705,6 +705,9 @@ D: Resizable*Array PMCs
 N: Matt Kennedy
 D: Some Env PMC method implementations and tests
 
+N: Matt Rajca
+D: Code refactoring
+
 N: Mattia Barbon
 D: Win32 fixes, dynamic PMC creation and loading
 

--- a/compilers/imcc/pcc.c
+++ b/compilers/imcc/pcc.c
@@ -527,7 +527,7 @@ typedef struct move_info_t {
 =item C<static int pcc_reg_mov(PARROT_INTERP, unsigned char d, unsigned char s,
 void *vinfo)>
 
-Callback for C<Parrot_register_move>. Inserts move instructions in stead of
+Callback for C<Parrot_util_register_move>. Inserts move instructions in stead of
 actually moving the registers.
 
 =cut
@@ -649,7 +649,7 @@ done:
         ;
     }
 
-    Parrot_register_move(interp, n, move_list, move_list + n, 255,
+    Parrot_util_register_move(interp, n, move_list, move_list + n, 255,
         pcc_reg_mov, NULL, &move_info);
 
     mem_sys_free(move_list);

--- a/docs/embed.pod
+++ b/docs/embed.pod
@@ -506,9 +506,9 @@ The list may also be augmented if additional functionality is required.
 
 =item C<Parrot_block_GC_sweep>
 
-=item C<Parrot_byte_index>
+=item C<Parrot_util_byte_index>
 
-=item C<Parrot_byte_rindex>
+=item C<Parrot_util_byte_rindex>
 
 =item C<Parrot_callback_C>
 
@@ -646,7 +646,7 @@ The list may also be augmented if additional functionality is required.
 
 =item C<Parrot_ns_find_named_item>
 
-=item C<Parrot_float_rand>
+=item C<Parrot_util_float_rand>
 
 =item C<Parrot_fprintf>
 
@@ -718,7 +718,7 @@ The list may also be augmented if additional functionality is required.
 
 =item C<Parrot_init_stacktop>
 
-=item C<Parrot_int_rand>
+=item C<Parrot_util_int_rand>
 
 =item C<Parrot_invalidate_method_cache>
 
@@ -1354,7 +1354,7 @@ The list may also be augmented if additional functionality is required.
 
 =item C<Parrot_push_mark>
 
-=item C<Parrot_range_rand>
+=item C<Parrot_util_range_rand>
 
 =item C<Parrot_regenerate_HLL_namespaces>
 
@@ -1364,7 +1364,7 @@ The list may also be augmented if additional functionality is required.
 
 =item C<Parrot_register_HLL_type>
 
-=item C<Parrot_register_move>
+=item C<Parrot_util_register_move>
 
 =item C<Parrot_register_pmc>
 
@@ -1418,7 +1418,7 @@ The list may also be augmented if additional functionality is required.
 
 =item C<Parrot_sprintf_s>
 
-=item C<Parrot_srand>
+=item C<Parrot_util_srand>
 
 =item C<Parrot_ns_store_global>
 
@@ -1524,7 +1524,7 @@ The list may also be augmented if additional functionality is required.
 
 =item C<Parrot_thaw_constants>
 
-=item C<Parrot_uint_rand>
+=item C<Parrot_util_uint_rand>
 
 =item C<Parrot_unblock_GC_mark>
 

--- a/include/parrot/misc.h
+++ b/include/parrot/misc.h
@@ -33,7 +33,7 @@ typedef int (*reg_move_func)(PARROT_INTERP, unsigned char d, unsigned char s, vo
 
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
-INTVAL Parrot_byte_index(SHIM_INTERP,
+INTVAL Parrot_util_byte_index(SHIM_INTERP,
     ARGIN(const STRING *base),
     ARGIN(const STRING *search),
     UINTVAL start_offset)
@@ -42,7 +42,7 @@ INTVAL Parrot_byte_index(SHIM_INTERP,
 
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
-INTVAL Parrot_byte_rindex(SHIM_INTERP,
+INTVAL Parrot_util_byte_rindex(SHIM_INTERP,
     ARGIN(const STRING *base),
     ARGIN(const STRING *search),
     UINTVAL start_offset)
@@ -51,18 +51,18 @@ INTVAL Parrot_byte_rindex(SHIM_INTERP,
 
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
-FLOATVAL Parrot_float_rand(INTVAL how_random);
+FLOATVAL Parrot_util_float_rand(INTVAL how_random);
 
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
-INTVAL Parrot_int_rand(INTVAL how_random);
+INTVAL Parrot_util_int_rand(INTVAL how_random);
 
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
-INTVAL Parrot_range_rand(INTVAL from, INTVAL to, INTVAL how_random);
+INTVAL Parrot_util_range_rand(INTVAL from, INTVAL to, INTVAL how_random);
 
 PARROT_EXPORT
-void Parrot_register_move(PARROT_INTERP,
+void Parrot_util_register_move(PARROT_INTERP,
     int n_regs,
     ARGOUT(unsigned char *dest_regs),
     ARGIN(unsigned char *src_regs),
@@ -77,28 +77,28 @@ void Parrot_register_move(PARROT_INTERP,
         FUNC_MODIFIES(*dest_regs);
 
 PARROT_EXPORT
-void Parrot_srand(INTVAL seed);
+void Parrot_util_srand(INTVAL seed);
 
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 PARROT_CANNOT_RETURN_NULL
-PMC* Parrot_tm_to_array(PARROT_INTERP, ARGIN(const struct tm *tm))
+PMC* Parrot_util_tm_to_array(PARROT_INTERP, ARGIN(const struct tm *tm))
         __attribute__nonnull__(1)
         __attribute__nonnull__(2);
 
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
-INTVAL Parrot_uint_rand(INTVAL how_random);
+INTVAL Parrot_util_uint_rand(INTVAL how_random);
 
 PARROT_CONST_FUNCTION
 PARROT_WARN_UNUSED_RESULT
-FLOATVAL floatval_mod(FLOATVAL n2, FLOATVAL n3);
+FLOATVAL Parrot_util_floatval_mod(FLOATVAL n2, FLOATVAL n3);
 
 PARROT_CONST_FUNCTION
 PARROT_WARN_UNUSED_RESULT
-INTVAL intval_mod(INTVAL i2, INTVAL i3);
+INTVAL Parrot_util_intval_mod(INTVAL i2, INTVAL i3);
 
-void Parrot_quicksort(PARROT_INTERP,
+void Parrot_util_quicksort(PARROT_INTERP,
     ARGMOD(void **data),
     UINTVAL n,
     ARGIN(PMC *cmp))
@@ -107,28 +107,28 @@ void Parrot_quicksort(PARROT_INTERP,
         __attribute__nonnull__(4)
         FUNC_MODIFIES(*data);
 
-#define ASSERT_ARGS_Parrot_byte_index __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_util_byte_index __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(base) \
     , PARROT_ASSERT_ARG(search))
-#define ASSERT_ARGS_Parrot_byte_rindex __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_util_byte_rindex __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(base) \
     , PARROT_ASSERT_ARG(search))
-#define ASSERT_ARGS_Parrot_float_rand __attribute__unused__ int _ASSERT_ARGS_CHECK = (0)
-#define ASSERT_ARGS_Parrot_int_rand __attribute__unused__ int _ASSERT_ARGS_CHECK = (0)
-#define ASSERT_ARGS_Parrot_range_rand __attribute__unused__ int _ASSERT_ARGS_CHECK = (0)
-#define ASSERT_ARGS_Parrot_register_move __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_util_float_rand __attribute__unused__ int _ASSERT_ARGS_CHECK = (0)
+#define ASSERT_ARGS_Parrot_util_int_rand __attribute__unused__ int _ASSERT_ARGS_CHECK = (0)
+#define ASSERT_ARGS_Parrot_util_range_rand __attribute__unused__ int _ASSERT_ARGS_CHECK = (0)
+#define ASSERT_ARGS_Parrot_util_register_move __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(dest_regs) \
     , PARROT_ASSERT_ARG(src_regs) \
     , PARROT_ASSERT_ARG(info))
-#define ASSERT_ARGS_Parrot_srand __attribute__unused__ int _ASSERT_ARGS_CHECK = (0)
-#define ASSERT_ARGS_Parrot_tm_to_array __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_util_srand __attribute__unused__ int _ASSERT_ARGS_CHECK = (0)
+#define ASSERT_ARGS_Parrot_util_tm_to_array __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(tm))
-#define ASSERT_ARGS_Parrot_uint_rand __attribute__unused__ int _ASSERT_ARGS_CHECK = (0)
-#define ASSERT_ARGS_floatval_mod __attribute__unused__ int _ASSERT_ARGS_CHECK = (0)
-#define ASSERT_ARGS_intval_mod __attribute__unused__ int _ASSERT_ARGS_CHECK = (0)
-#define ASSERT_ARGS_Parrot_quicksort __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_util_uint_rand __attribute__unused__ int _ASSERT_ARGS_CHECK = (0)
+#define ASSERT_ARGS_Parrot_util_floatval_mod __attribute__unused__ int _ASSERT_ARGS_CHECK = (0)
+#define ASSERT_ARGS_Parrot_util_intval_mod __attribute__unused__ int _ASSERT_ARGS_CHECK = (0)
+#define ASSERT_ARGS_Parrot_util_quicksort __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(data) \
     , PARROT_ASSERT_ARG(cmp))

--- a/src/dynoplibs/math.ops
+++ b/src/dynoplibs/math.ops
@@ -193,7 +193,7 @@ Set $1 to a random floating point number between 0 and 1, inclusive.
 =cut
 
 inline op rand(out NUM) {
-    $1 = Parrot_float_rand(0);
+    $1 = Parrot_util_float_rand(0);
 }
 
 =item B<rand>(out INT)
@@ -203,7 +203,7 @@ Set $1 to a random integer between C<[-2^31, 2^31)> .
 =cut
 
 inline op rand(out INT) {
-    $1 = Parrot_int_rand(0);
+    $1 = Parrot_util_int_rand(0);
 }
 
 =item B<rand>(out NUM, in NUM)
@@ -213,7 +213,7 @@ Set $1 to a random floating point number between 0 and and $2, inclusive.
 =cut
 
 inline op rand(out NUM, in NUM) {
-    $1 = $2 * Parrot_float_rand(0);
+    $1 = $2 * Parrot_util_float_rand(0);
 }
 
 =item B<rand>(out INT, in INT)
@@ -223,7 +223,7 @@ Set $1 to a integer between 0 and and $2, inclusive.
 =cut
 
 inline op rand(out INT, in INT) {
-    $1 = Parrot_range_rand(0, $2, 0);
+    $1 = Parrot_util_range_rand(0, $2, 0);
 }
 
 =item B<rand>(out NUM, in NUM, in NUM)
@@ -233,7 +233,7 @@ Set $1 to a random floating point number between $2 and and $3, inclusive.
 =cut
 
 inline op rand(out NUM, in NUM, in NUM) {
-    $1 = $2 + ($3 - $2) * Parrot_float_rand(0);
+    $1 = $2 + ($3 - $2) * Parrot_util_float_rand(0);
 }
 
 =item B<srand>(in NUM)
@@ -243,7 +243,7 @@ Set the random number seed to $1. $1 is casted to an INTVAL.
 =cut
 
 inline op srand(in NUM) {
-    Parrot_srand((INTVAL)$1);
+    Parrot_util_srand((INTVAL)$1);
 }
 
 =item B<srand>(in INT)
@@ -253,7 +253,7 @@ Set the random number seed to $1.
 =cut
 
 inline op srand(in INT) {
-    Parrot_srand((INTVAL)$1);
+    Parrot_util_srand((INTVAL)$1);
 }
 
 =item B<rand>(out INT, in INT, in INT)
@@ -263,7 +263,7 @@ Set $1 to a integer between $2 and and $3, inclusive.
 =cut
 
 inline op rand(out INT, in INT, in INT) {
-    $1 = Parrot_range_rand($2, $3, 0);
+    $1 = Parrot_util_range_rand($2, $3, 0);
 }
 
 =back

--- a/src/dynoplibs/sys.ops
+++ b/src/dynoplibs/sys.ops
@@ -113,14 +113,14 @@ op decodetime(out PMC, in INT) {
     struct tm tm;
     const time_t t = (time_t) $2;
     Parrot_gmtime_r(&t, &tm);
-    $1 = Parrot_tm_to_array(interp, &tm);
+    $1 = Parrot_util_tm_to_array(interp, &tm);
 }
 
 op decodelocaltime(out PMC, in INT) {
     struct tm tm;
     const time_t t = (time_t) $2;
     Parrot_localtime_r(&t, &tm);
-    $1 = Parrot_tm_to_array(interp, &tm);
+    $1 = Parrot_util_tm_to_array(interp, &tm);
 }
 
 ########################################

--- a/src/exit.c
+++ b/src/exit.c
@@ -27,7 +27,8 @@ called by C<Parrot_x_exit()> when the interpreter exits.
 
 /*
 
-=item C<void Parrot_x_on_exit(PARROT_INTERP, exit_handler_f function, void *arg)>
+=item C<void Parrot_x_on_exit(PARROT_INTERP, exit_handler_f function, void
+*arg)>
 
 Register the specified function to be called on exit.
 

--- a/src/ops/core_ops.c
+++ b/src/ops/core_ops.c
@@ -19144,28 +19144,28 @@ return (opcode_t *)cur_opcode + 2;}
 opcode_t *
 Parrot_mod_i_i(opcode_t *cur_opcode, PARROT_INTERP)  {
     const Parrot_Context * const CUR_CTX = Parrot_pcc_get_context_struct(interp, interp->ctx);
-    IREG(1) = intval_mod(IREG(1), IREG(2));
+    IREG(1) = Parrot_util_intval_mod(IREG(1), IREG(2));
 
 return (opcode_t *)cur_opcode + 3;}
 
 opcode_t *
 Parrot_mod_i_ic(opcode_t *cur_opcode, PARROT_INTERP)  {
     const Parrot_Context * const CUR_CTX = Parrot_pcc_get_context_struct(interp, interp->ctx);
-    IREG(1) = intval_mod(IREG(1), ICONST(2));
+    IREG(1) = Parrot_util_intval_mod(IREG(1), ICONST(2));
 
 return (opcode_t *)cur_opcode + 3;}
 
 opcode_t *
 Parrot_mod_n_n(opcode_t *cur_opcode, PARROT_INTERP)  {
     const Parrot_Context * const CUR_CTX = Parrot_pcc_get_context_struct(interp, interp->ctx);
-    NREG(1) = floatval_mod(NREG(1), NREG(2));
+    NREG(1) = Parrot_util_floatval_mod(NREG(1), NREG(2));
 
 return (opcode_t *)cur_opcode + 3;}
 
 opcode_t *
 Parrot_mod_n_nc(opcode_t *cur_opcode, PARROT_INTERP)  {
     const Parrot_Context * const CUR_CTX = Parrot_pcc_get_context_struct(interp, interp->ctx);
-    NREG(1) = floatval_mod(NREG(1), NCONST(2));
+    NREG(1) = Parrot_util_floatval_mod(NREG(1), NCONST(2));
 
 return (opcode_t *)cur_opcode + 3;}
 
@@ -19207,42 +19207,42 @@ return (opcode_t *)cur_opcode + 3;}
 opcode_t *
 Parrot_mod_i_i_i(opcode_t *cur_opcode, PARROT_INTERP)  {
     const Parrot_Context * const CUR_CTX = Parrot_pcc_get_context_struct(interp, interp->ctx);
-    IREG(1) = intval_mod(IREG(2), IREG(3));
+    IREG(1) = Parrot_util_intval_mod(IREG(2), IREG(3));
 
 return (opcode_t *)cur_opcode + 4;}
 
 opcode_t *
 Parrot_mod_i_ic_i(opcode_t *cur_opcode, PARROT_INTERP)  {
     const Parrot_Context * const CUR_CTX = Parrot_pcc_get_context_struct(interp, interp->ctx);
-    IREG(1) = intval_mod(ICONST(2), IREG(3));
+    IREG(1) = Parrot_util_intval_mod(ICONST(2), IREG(3));
 
 return (opcode_t *)cur_opcode + 4;}
 
 opcode_t *
 Parrot_mod_i_i_ic(opcode_t *cur_opcode, PARROT_INTERP)  {
     const Parrot_Context * const CUR_CTX = Parrot_pcc_get_context_struct(interp, interp->ctx);
-    IREG(1) = intval_mod(IREG(2), ICONST(3));
+    IREG(1) = Parrot_util_intval_mod(IREG(2), ICONST(3));
 
 return (opcode_t *)cur_opcode + 4;}
 
 opcode_t *
 Parrot_mod_n_n_n(opcode_t *cur_opcode, PARROT_INTERP)  {
     const Parrot_Context * const CUR_CTX = Parrot_pcc_get_context_struct(interp, interp->ctx);
-    NREG(1) = floatval_mod(NREG(2), NREG(3));
+    NREG(1) = Parrot_util_floatval_mod(NREG(2), NREG(3));
 
 return (opcode_t *)cur_opcode + 4;}
 
 opcode_t *
 Parrot_mod_n_nc_n(opcode_t *cur_opcode, PARROT_INTERP)  {
     const Parrot_Context * const CUR_CTX = Parrot_pcc_get_context_struct(interp, interp->ctx);
-    NREG(1) = floatval_mod(NCONST(2), NREG(3));
+    NREG(1) = Parrot_util_floatval_mod(NCONST(2), NREG(3));
 
 return (opcode_t *)cur_opcode + 4;}
 
 opcode_t *
 Parrot_mod_n_n_nc(opcode_t *cur_opcode, PARROT_INTERP)  {
     const Parrot_Context * const CUR_CTX = Parrot_pcc_get_context_struct(interp, interp->ctx);
-    NREG(1) = floatval_mod(NREG(2), NCONST(3));
+    NREG(1) = Parrot_util_floatval_mod(NREG(2), NCONST(3));
 
 return (opcode_t *)cur_opcode + 4;}
 

--- a/src/ops/math.ops
+++ b/src/ops/math.ops
@@ -490,11 +490,11 @@ References:
 =cut
 
 op mod(inout INT, in INT) :base_core {
-    $1 = intval_mod($1, $2);
+    $1 = Parrot_util_intval_mod($1, $2);
 }
 
 op mod(inout NUM, in NUM) :base_core {
-    $1 = floatval_mod($1, $2);
+    $1 = Parrot_util_floatval_mod($1, $2);
 }
 
 inline op mod(invar PMC, invar PMC) :base_core {
@@ -510,11 +510,11 @@ inline op mod(invar PMC, in NUM) :base_core {
 }
 
 op mod(out INT, in INT, in INT) :base_core {
-    $1 = intval_mod($2, $3);
+    $1 = Parrot_util_intval_mod($2, $3);
 }
 
 op mod(out NUM, in NUM, in NUM) :base_core {
-    $1 = floatval_mod($2, $3);
+    $1 = Parrot_util_floatval_mod($2, $3);
 }
 
 inline op mod(invar PMC, invar PMC, invar PMC) :base_core {

--- a/src/pmc/fixedintegerarray.pmc
+++ b/src/pmc/fixedintegerarray.pmc
@@ -631,7 +631,7 @@ Sort the array and return self.
                 qsort(int_array, n, sizeof (INTVAL),
                         (int (*)(const void *, const void*))auxcmpfunc);
             else
-                Parrot_quicksort(INTERP, (void**)int_array, n, cmp_func);
+                Parrot_util_quicksort(INTERP, (void**)int_array, n, cmp_func);
         }
         RETURN(PMC *SELF);
     }

--- a/src/pmc/fixedpmcarray.pmc
+++ b/src/pmc/fixedpmcarray.pmc
@@ -54,7 +54,7 @@ Sort this array, optionally using the provided cmp_func
                 Parrot_pcc_invoke_method_from_c_args(INTERP, parent, CONST_STRING(INTERP, "sort"), "P->", cmp_func);
             }
             else
-                Parrot_quicksort(INTERP, (void **)PMC_array(SELF), n, cmp_func);
+                Parrot_util_quicksort(INTERP, (void **)PMC_array(SELF), n, cmp_func);
         }
         RETURN(PMC *SELF);
     }

--- a/src/pmc/integer.pmc
+++ b/src/pmc/integer.pmc
@@ -925,7 +925,7 @@ Calculates modulus in place.
                     "int modulus by zero");
 
         return Parrot_pmc_new_init_int(INTERP, VTABLE_type(INTERP, SELF),
-                intval_mod(SELF.get_integer(), d));
+                Parrot_util_intval_mod(SELF.get_integer(), d));
     }
 
 
@@ -935,7 +935,7 @@ Calculates modulus in place.
                     "int modulus by zero");
 
         return Parrot_pmc_new_init_int(INTERP, VTABLE_type(INTERP, SELF),
-                intval_mod(SELF.get_integer(), value));
+                Parrot_util_intval_mod(SELF.get_integer(), value));
     }
 
 
@@ -945,7 +945,7 @@ Calculates modulus in place.
                     "int modulus by zero");
 
         return Parrot_pmc_new_init_int(INTERP, VTABLE_type(INTERP, SELF),
-                intval_mod(SELF.get_integer(), (INTVAL)value));
+                Parrot_util_intval_mod(SELF.get_integer(), (INTVAL)value));
     }
 
 
@@ -964,7 +964,7 @@ Calculates modulus in place.
                     "int modulus by zero");
 
         VTABLE_set_integer_native(INTERP, SELF,
-                intval_mod(SELF.get_integer(), d));
+                Parrot_util_intval_mod(SELF.get_integer(), d));
     }
 
 
@@ -974,7 +974,7 @@ Calculates modulus in place.
                     "int modulus by zero");
 
         VTABLE_set_integer_native(INTERP, SELF,
-                intval_mod(SELF.get_integer() , value));
+                Parrot_util_intval_mod(SELF.get_integer() , value));
     }
 
 
@@ -984,7 +984,7 @@ Calculates modulus in place.
                     "int modulus by zero");
 
         VTABLE_set_integer_native(INTERP, SELF,
-                intval_mod(SELF.get_integer() , (INTVAL)value));
+                Parrot_util_intval_mod(SELF.get_integer() , (INTVAL)value));
     }
 
 /*

--- a/src/pmc/scalar.pmc
+++ b/src/pmc/scalar.pmc
@@ -523,7 +523,7 @@ Calculates modulus inplace
         dest = Parrot_pmc_new(INTERP, VTABLE_type(INTERP, SELF));
 
         VTABLE_set_number_native(INTERP, dest,
-                floatval_mod(SELF.get_number(), d));
+                Parrot_util_floatval_mod(SELF.get_number(), d));
         return dest;
     }
 
@@ -535,7 +535,7 @@ Calculates modulus inplace
         dest = Parrot_pmc_new(INTERP, VTABLE_type(INTERP, SELF));
 
         VTABLE_set_number_native(INTERP, dest,
-                floatval_mod(SELF.get_number(), (FLOATVAL)value));
+                Parrot_util_floatval_mod(SELF.get_number(), (FLOATVAL)value));
         return dest;
     }
 
@@ -547,7 +547,7 @@ Calculates modulus inplace
         dest = Parrot_pmc_new(INTERP, VTABLE_type(INTERP, SELF));
 
         VTABLE_set_number_native(INTERP, dest,
-                floatval_mod(SELF.get_number(), value));
+                Parrot_util_floatval_mod(SELF.get_number(), value));
         return dest;
     }
 
@@ -559,7 +559,7 @@ Calculates modulus inplace
                 "float modulus by zero");
 
         VTABLE_set_number_native(INTERP, SELF,
-                floatval_mod(SELF.get_number(), d));
+                Parrot_util_floatval_mod(SELF.get_number(), d));
     }
 
     VTABLE void i_modulus_int(INTVAL value) {
@@ -568,7 +568,7 @@ Calculates modulus inplace
                 "float modulus by zero");
 
         VTABLE_set_number_native(INTERP, SELF,
-                floatval_mod(SELF.get_number(), (FLOATVAL)value));
+                Parrot_util_floatval_mod(SELF.get_number(), (FLOATVAL)value));
     }
 
     VTABLE void i_modulus_float(FLOATVAL value) {
@@ -577,7 +577,7 @@ Calculates modulus inplace
                 "float modulus by zero");
 
         VTABLE_set_number_native(INTERP, SELF,
-                floatval_mod(SELF.get_number(), value));
+                Parrot_util_floatval_mod(SELF.get_number(), value));
     }
 
 /*

--- a/src/string/api.c
+++ b/src/string/api.c
@@ -129,8 +129,8 @@ Parrot_str_init(PARROT_INTERP)
     /* interp is initialized from zeroed memory, so this is fine */
     else if (interp->hash_seed == 0) {
         /* TT #64 - use an entropy source once available */
-        Parrot_srand(Parrot_intval_time());
-        interp->hash_seed = Parrot_uint_rand(0);
+        Parrot_util_srand(Parrot_intval_time());
+        interp->hash_seed = Parrot_util_uint_rand(0);
     }
 
     /* initialize the constant string table */

--- a/src/string/encoding/shared.c
+++ b/src/string/encoding/shared.c
@@ -727,7 +727,7 @@ fixed8_index(PARROT_INTERP, ARGIN(const STRING *src),
     ||  !STRING_length(search))
         return -1;
 
-    return Parrot_byte_index(interp, src, search, offset);
+    return Parrot_util_byte_index(interp, src, search, offset);
 }
 
 
@@ -756,7 +756,7 @@ fixed8_rindex(PARROT_INTERP, ARGIN(const STRING *src),
             "Cross-charset rindex not supported");
 
     PARROT_ASSERT(STRING_max_bytes_per_codepoint(src) == 1);
-    retval = Parrot_byte_rindex(interp, src, search_string, offset);
+    retval = Parrot_util_byte_rindex(interp, src, search_string, offset);
     return retval;
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -25,7 +25,7 @@ Opcode helper functions that don't really fit elsewhere.
 
 typedef unsigned short _rand_buf[3];
 
-/* Parrot_register_move companion functions i and data */
+/* Parrot_util_register_move companion functions i and data */
 typedef struct parrot_prm_context {
     unsigned char *dest_regs;
     unsigned char *src_regs;
@@ -95,7 +95,7 @@ static void rec_climb_back_and_mark(
 
 /*
 
-=item C<INTVAL intval_mod(INTVAL i2, INTVAL i3)>
+=item C<INTVAL Parrot_util_intval_mod(INTVAL i2, INTVAL i3)>
 
 NOTE: This "corrected mod" algorithm is based on the C code on page 70
 of [1]. Assuming correct behavior of the built-in mod operator (%) with
@@ -122,9 +122,9 @@ Mathematics*, Second Edition. Addison-Wesley, 1994.
 PARROT_CONST_FUNCTION
 PARROT_WARN_UNUSED_RESULT
 INTVAL
-intval_mod(INTVAL i2, INTVAL i3)
+Parrot_util_intval_mod(INTVAL i2, INTVAL i3)
 {
-    ASSERT_ARGS(intval_mod)
+    ASSERT_ARGS(Parrot_util_intval_mod)
     INTVAL z = i3;
 
     if (z == 0)
@@ -157,7 +157,7 @@ intval_mod(INTVAL i2, INTVAL i3)
 
 /*
 
-=item C<FLOATVAL floatval_mod(FLOATVAL n2, FLOATVAL n3)>
+=item C<FLOATVAL Parrot_util_floatval_mod(FLOATVAL n2, FLOATVAL n3)>
 
 Returns C<n2 mod n3>.
 
@@ -170,9 +170,9 @@ Includes a workaround for buggy code generation in the C<lcc> compiler.
 PARROT_CONST_FUNCTION
 PARROT_WARN_UNUSED_RESULT
 FLOATVAL
-floatval_mod(FLOATVAL n2, FLOATVAL n3)
+Parrot_util_floatval_mod(FLOATVAL n2, FLOATVAL n3)
 {
-    ASSERT_ARGS(floatval_mod)
+    ASSERT_ARGS(Parrot_util_floatval_mod)
 #ifdef __LCC__
 
     /* Another workaround for buggy code generation in the lcc compiler-
@@ -412,7 +412,7 @@ _srand48(long seed)
 
 /*
 
-=item C<FLOATVAL Parrot_float_rand(INTVAL how_random)>
+=item C<FLOATVAL Parrot_util_float_rand(INTVAL how_random)>
 
 Returns a C<FLOATVAL> uniformly distributed in the in the interval
 C<[0.0, 1.0]>.
@@ -426,9 +426,9 @@ C<how_random> is currently ignored.
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 FLOATVAL
-Parrot_float_rand(INTVAL how_random)
+Parrot_util_float_rand(INTVAL how_random)
 {
-    ASSERT_ARGS(Parrot_float_rand)
+    ASSERT_ARGS(Parrot_util_float_rand)
     UNUSED(how_random);
 
     return _drand48();          /* [0.0..1.0] */
@@ -436,7 +436,7 @@ Parrot_float_rand(INTVAL how_random)
 
 /*
 
-=item C<INTVAL Parrot_uint_rand(INTVAL how_random)>
+=item C<INTVAL Parrot_util_uint_rand(INTVAL how_random)>
 
 Returns an C<INTVAL> uniformly distributed in the interval C<[0, 2^31)>.
 
@@ -449,9 +449,9 @@ C<how_random> is ignored.
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 INTVAL
-Parrot_uint_rand(INTVAL how_random)
+Parrot_util_uint_rand(INTVAL how_random)
 {
-    ASSERT_ARGS(Parrot_uint_rand)
+    ASSERT_ARGS(Parrot_util_uint_rand)
     UNUSED(how_random);
 
     return _lrand48();          /* [0..2^31] */
@@ -459,7 +459,7 @@ Parrot_uint_rand(INTVAL how_random)
 
 /*
 
-=item C<INTVAL Parrot_int_rand(INTVAL how_random)>
+=item C<INTVAL Parrot_util_int_rand(INTVAL how_random)>
 
 Returns an C<INTVAL> in the interval C<[-2^31, 2^31)>.
 
@@ -472,9 +472,9 @@ C<how_random> is ignored.
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 INTVAL
-Parrot_int_rand(INTVAL how_random)
+Parrot_util_int_rand(INTVAL how_random)
 {
-    ASSERT_ARGS(Parrot_int_rand)
+    ASSERT_ARGS(Parrot_util_int_rand)
     UNUSED(how_random);
 
     return _mrand48();          /* [-2^31..2^31] */
@@ -482,7 +482,8 @@ Parrot_int_rand(INTVAL how_random)
 
 /*
 
-=item C<INTVAL Parrot_range_rand(INTVAL from, INTVAL to, INTVAL how_random)>
+=item C<INTVAL Parrot_util_range_rand(INTVAL from, INTVAL to, INTVAL
+how_random)>
 
 Returns an C<INTVAL> in the range C<[from, to]>.
 
@@ -495,11 +496,11 @@ C<how_random> is ignored.
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 INTVAL
-Parrot_range_rand(INTVAL from, INTVAL to, INTVAL how_random)
+Parrot_util_range_rand(INTVAL from, INTVAL to, INTVAL how_random)
 {
-    ASSERT_ARGS(Parrot_range_rand)
+    ASSERT_ARGS(Parrot_util_range_rand)
     const double spread = (double)(to - from + 1);
-    const double randpart = Parrot_float_rand(how_random);
+    const double randpart = Parrot_util_float_rand(how_random);
     const INTVAL raw = from + (INTVAL)(spread * randpart);
 
     return raw;
@@ -507,7 +508,7 @@ Parrot_range_rand(INTVAL from, INTVAL to, INTVAL how_random)
 
 /*
 
-=item C<void Parrot_srand(INTVAL seed)>
+=item C<void Parrot_util_srand(INTVAL seed)>
 
 Seeds the random number generator with C<seed>.
 
@@ -517,9 +518,9 @@ Seeds the random number generator with C<seed>.
 
 PARROT_EXPORT
 void
-Parrot_srand(INTVAL seed)
+Parrot_util_srand(INTVAL seed)
 {
-    ASSERT_ARGS(Parrot_srand)
+    ASSERT_ARGS(Parrot_util_srand)
     _srand48(seed);
 }
 
@@ -540,7 +541,7 @@ typedef enum {
 
 /*
 
-=item C<PMC* Parrot_tm_to_array(PARROT_INTERP, const struct tm *tm)>
+=item C<PMC* Parrot_util_tm_to_array(PARROT_INTERP, const struct tm *tm)>
 
 Helper to convert a B<struct tm *> to an Array
 
@@ -552,9 +553,9 @@ PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 PARROT_CANNOT_RETURN_NULL
 PMC*
-Parrot_tm_to_array(PARROT_INTERP, ARGIN(const struct tm *tm))
+Parrot_util_tm_to_array(PARROT_INTERP, ARGIN(const struct tm *tm))
 {
-    ASSERT_ARGS(Parrot_tm_to_array)
+    ASSERT_ARGS(Parrot_util_tm_to_array)
 
     PMC * const Array = Parrot_pmc_new(interp,
         Parrot_get_ctx_HLL_type(interp, enum_class_FixedIntegerArray));
@@ -575,8 +576,8 @@ Parrot_tm_to_array(PARROT_INTERP, ARGIN(const struct tm *tm))
 
 /*
 
-=item C<INTVAL Parrot_byte_index(PARROT_INTERP, const STRING *base, const STRING
-*search, UINTVAL start_offset)>
+=item C<INTVAL Parrot_util_byte_index(PARROT_INTERP, const STRING *base, const
+STRING *search, UINTVAL start_offset)>
 
 Looks for the location of a substring within a longer string.  Takes
 pointers to the strings and the offset within the string at which
@@ -591,10 +592,10 @@ Returns an offset value if it is found, or -1 if no match.
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 INTVAL
-Parrot_byte_index(SHIM_INTERP, ARGIN(const STRING *base),
+Parrot_util_byte_index(SHIM_INTERP, ARGIN(const STRING *base),
         ARGIN(const STRING *search), UINTVAL start_offset)
 {
-    ASSERT_ARGS(Parrot_byte_index)
+    ASSERT_ARGS(Parrot_util_byte_index)
     const char * const str_start  = base->strstart;
     const INTVAL       str_len    = base->strlen;
     const char * const search_str = search->strstart;
@@ -625,10 +626,10 @@ Parrot_byte_index(SHIM_INTERP, ARGIN(const STRING *base),
 
 /*
 
-=item C<INTVAL Parrot_byte_rindex(PARROT_INTERP, const STRING *base, const
+=item C<INTVAL Parrot_util_byte_rindex(PARROT_INTERP, const STRING *base, const
 STRING *search, UINTVAL start_offset)>
 
-Substring search (like Parrot_byte_index), but works backwards,
+Substring search (like Parrot_util_byte_index), but works backwards,
 from the rightmost end of the string.
 
 Returns offset value or -1 (if no match).
@@ -640,10 +641,10 @@ Returns offset value or -1 (if no match).
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 INTVAL
-Parrot_byte_rindex(SHIM_INTERP, ARGIN(const STRING *base),
+Parrot_util_byte_rindex(SHIM_INTERP, ARGIN(const STRING *base),
         ARGIN(const STRING *search), UINTVAL start_offset)
 {
-    ASSERT_ARGS(Parrot_byte_rindex)
+    ASSERT_ARGS(Parrot_util_byte_rindex)
     const INTVAL searchlen          = search->strlen;
     const char * const search_start = (const char *)(search->strstart);
     UINTVAL max_possible_offset     = (base->strlen - search->strlen);
@@ -668,7 +669,7 @@ Parrot_byte_rindex(SHIM_INTERP, ARGIN(const STRING *base),
 =item C<static void rec_climb_back_and_mark(int node_index, const
 parrot_prm_context *c)>
 
-Recursive function, used by Parrot_register_move to
+Recursive function, used by Parrot_util_register_move to
 climb back the graph of register moves operations.
 
 The node must have a predecessor: it is implicit because if a node has
@@ -719,7 +720,7 @@ rec_climb_back_and_mark(int node_index, ARGIN(const parrot_prm_context *c))
 =item C<static void process_cycle_without_exit(int node_index, const
 parrot_prm_context *c)>
 
-Recursive function, used by Parrot_register_move to handle the case
+Recursive function, used by Parrot_util_register_move to handle the case
 of cycles without exits, that are cycles of move ops between registers
 where each register has exactly one predecessor and one successor
 
@@ -756,7 +757,7 @@ process_cycle_without_exit(int node_index, ARGIN(const parrot_prm_context *c))
 
 /*
 
-=item C<void Parrot_register_move(PARROT_INTERP, int n_regs, unsigned char
+=item C<void Parrot_util_register_move(PARROT_INTERP, int n_regs, unsigned char
 *dest_regs, unsigned char *src_regs, unsigned char temp_reg, reg_move_func mov,
 reg_move_func mov_alt, void *info)>
 
@@ -811,7 +812,7 @@ TODO: Add tests for the above conditions.
 
 PARROT_EXPORT
 void
-Parrot_register_move(PARROT_INTERP,
+Parrot_util_register_move(PARROT_INTERP,
         int n_regs,
         ARGOUT(unsigned char *dest_regs),
         ARGIN(unsigned char *src_regs),
@@ -820,7 +821,7 @@ Parrot_register_move(PARROT_INTERP,
         reg_move_func mov_alt,
         ARGIN(void *info))
 {
-    ASSERT_ARGS(Parrot_register_move)
+    ASSERT_ARGS(Parrot_util_register_move)
     int i;
     int max_reg       = 0;
     int* nb_succ      = NULL;
@@ -936,7 +937,8 @@ COMPARE(PARROT_INTERP, ARGIN(void *a), ARGIN(void *b), ARGIN(PMC *cmp))
 
 /*
 
-=item C<void Parrot_quicksort(PARROT_INTERP, void **data, UINTVAL n, PMC *cmp)>
+=item C<void Parrot_util_quicksort(PARROT_INTERP, void **data, UINTVAL n, PMC
+*cmp)>
 
 Perform a quicksort on a PMC array.
 
@@ -945,9 +947,9 @@ Perform a quicksort on a PMC array.
 */
 
 void
-Parrot_quicksort(PARROT_INTERP, ARGMOD(void **data), UINTVAL n, ARGIN(PMC *cmp))
+Parrot_util_quicksort(PARROT_INTERP, ARGMOD(void **data), UINTVAL n, ARGIN(PMC *cmp))
 {
-    ASSERT_ARGS(Parrot_quicksort)
+    ASSERT_ARGS(Parrot_util_quicksort)
     while (n > 1) {
         UINTVAL i, j, ln, rn;
         void *temp;
@@ -984,12 +986,12 @@ Parrot_quicksort(PARROT_INTERP, ARGMOD(void **data), UINTVAL n, ARGIN(PMC *cmp))
         rn = n - ++j;
 
         if (ln < rn) {
-            Parrot_quicksort(interp, data, ln, cmp);
+            Parrot_util_quicksort(interp, data, ln, cmp);
             data += j;
             n = rn;
         }
         else {
-            Parrot_quicksort(interp, data + j, rn, cmp);
+            Parrot_util_quicksort(interp, data + j, rn, cmp);
             n = ln;
         }
     }


### PR DESCRIPTION
`make headerizer` run and `make test` passes with no errors.

task: http://www.google-melange.com/gci/task/show/google/gci2010/parrot_perl_foundations/t129035224491#c1001
