### PR TITLE
GCI Task - Rename all public functions in src/key.c from key_* to Parrot_key_*

### DIFF
--- a/compilers/imcc/pbc.c
+++ b/compilers/imcc/pbc.c
@@ -1640,9 +1640,9 @@ build_key(PARROT_INTERP, ARGIN(SymReg *key_reg))
             regno = r->color >= 0 ? r->color : -1 - r->color;
 
             if (r->set == 'I')
-                key_set_register(interp, tail, regno, KEY_integer_FLAG);
+                Parrot_key_set_register(interp, tail, regno, KEY_integer_FLAG);
             else if (r->set == 'S')
-                key_set_register(interp, tail, regno, KEY_string_FLAG);
+                Parrot_key_set_register(interp, tail, regno, KEY_string_FLAG);
             else
                 IMCC_fatal(interp, 1, "build_key: wrong register set\n");
 
@@ -1658,11 +1658,11 @@ build_key(PARROT_INTERP, ARGIN(SymReg *key_reg))
             switch (r->set) {
               case 'S':                       /* P["key"] */
                 /* str constant */
-                key_set_string(interp, tail, ct->str.constants[r->color]);
+                Parrot_key_set_string(interp, tail, ct->str.constants[r->color]);
                 break;
               case 'I':                       /* P[;42;..] */
                 /* int constant */
-                key_set_integer(interp, tail, atol(r->name));
+                Parrot_key_set_integer(interp, tail, atol(r->name));
                 break;
               default:
                 IMCC_fatal(interp, 1, "build_key: unknown set\n");
@@ -1675,7 +1675,7 @@ build_key(PARROT_INTERP, ARGIN(SymReg *key_reg))
     }
 
     {
-        STRING *name      = key_set_to_string(interp, head);
+        STRING *name      = Parrot_key_set_to_string(interp, head);
         const char *cname = Parrot_str_to_cstring(interp, name);
         SymReg * const r  = _get_sym(&IMCC_INFO(interp)->globals->cs->key_consts, cname);
 

--- a/include/parrot/key.h
+++ b/include/parrot/key.h
@@ -42,7 +42,7 @@ typedef enum {
 PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
 PARROT_IGNORABLE_RESULT
-PMC * key_append(PARROT_INTERP, ARGMOD(PMC *key1), ARGIN(PMC *key2))
+PMC * Parrot_key_append(PARROT_INTERP, ARGMOD(PMC *key1), ARGIN(PMC *key2))
         __attribute__nonnull__(1)
         __attribute__nonnull__(2)
         __attribute__nonnull__(3)
@@ -50,80 +50,80 @@ PMC * key_append(PARROT_INTERP, ARGMOD(PMC *key1), ARGIN(PMC *key2))
 
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
-INTVAL key_integer(PARROT_INTERP, ARGIN(PMC *key))
+INTVAL Parrot_key_integer(PARROT_INTERP, ARGIN(PMC *key))
         __attribute__nonnull__(1)
         __attribute__nonnull__(2);
 
 PARROT_EXPORT
-void key_mark(PARROT_INTERP, ARGIN(PMC *key))
+void Parrot_key_mark(PARROT_INTERP, ARGIN(PMC *key))
         __attribute__nonnull__(1)
         __attribute__nonnull__(2);
 
 PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
 PARROT_WARN_UNUSED_RESULT
-PMC * key_new(PARROT_INTERP)
+PMC * Parrot_key_new(PARROT_INTERP)
         __attribute__nonnull__(1);
 
 PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
 PARROT_WARN_UNUSED_RESULT
-PMC * key_new_cstring(PARROT_INTERP, ARGIN_NULLOK(const char *value))
+PMC * Parrot_key_new_cstring(PARROT_INTERP, ARGIN_NULLOK(const char *value))
         __attribute__nonnull__(1);
 
 PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
 PARROT_WARN_UNUSED_RESULT
-PMC * key_new_integer(PARROT_INTERP, INTVAL value)
+PMC * Parrot_key_new_integer(PARROT_INTERP, INTVAL value)
         __attribute__nonnull__(1);
 
 PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
 PARROT_WARN_UNUSED_RESULT
-PMC * key_new_number(PARROT_INTERP, FLOATVAL value)
+PMC * Parrot_key_new_number(PARROT_INTERP, FLOATVAL value)
         __attribute__nonnull__(1);
 
 PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
 PARROT_WARN_UNUSED_RESULT
-PMC * key_new_string(PARROT_INTERP, ARGIN(STRING *value))
+PMC * Parrot_key_new_string(PARROT_INTERP, ARGIN(STRING *value))
         __attribute__nonnull__(1)
         __attribute__nonnull__(2);
 
 PARROT_EXPORT
 PARROT_CAN_RETURN_NULL
 PARROT_WARN_UNUSED_RESULT
-PMC * key_next(PARROT_INTERP, ARGIN(PMC *key))
+PMC * Parrot_key_next(PARROT_INTERP, ARGIN(PMC *key))
         __attribute__nonnull__(1)
         __attribute__nonnull__(2);
 
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
-FLOATVAL key_number(PARROT_INTERP, ARGIN(PMC *key))
+FLOATVAL Parrot_key_number(PARROT_INTERP, ARGIN(PMC *key))
         __attribute__nonnull__(1)
         __attribute__nonnull__(2);
 
 PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
 PARROT_WARN_UNUSED_RESULT
-PMC * key_pmc(PARROT_INTERP, ARGIN(PMC *key))
+PMC * Parrot_key_pmc(PARROT_INTERP, ARGIN(PMC *key))
         __attribute__nonnull__(1)
         __attribute__nonnull__(2);
 
 PARROT_EXPORT
-void key_set_integer(PARROT_INTERP, ARGMOD(PMC *key), INTVAL value)
+void Parrot_key_set_integer(PARROT_INTERP, ARGMOD(PMC *key), INTVAL value)
         __attribute__nonnull__(1)
         __attribute__nonnull__(2)
         FUNC_MODIFIES(*key);
 
 PARROT_EXPORT
-void key_set_number(PARROT_INTERP, ARGMOD(PMC *key), FLOATVAL value)
+void Parrot_key_set_number(PARROT_INTERP, ARGMOD(PMC *key), FLOATVAL value)
         __attribute__nonnull__(1)
         __attribute__nonnull__(2)
         FUNC_MODIFIES(*key);
 
 PARROT_EXPORT
-void key_set_register(PARROT_INTERP,
+void Parrot_key_set_register(PARROT_INTERP,
     ARGMOD(PMC *key),
     INTVAL value,
     INTVAL flag)
@@ -132,7 +132,9 @@ void key_set_register(PARROT_INTERP,
         FUNC_MODIFIES(*key);
 
 PARROT_EXPORT
-void key_set_string(PARROT_INTERP, ARGMOD(PMC *key), ARGIN(STRING *value))
+void Parrot_key_set_string(PARROT_INTERP,
+    ARGMOD(PMC *key),
+    ARGIN(STRING *value))
         __attribute__nonnull__(1)
         __attribute__nonnull__(2)
         __attribute__nonnull__(3)
@@ -141,71 +143,71 @@ void key_set_string(PARROT_INTERP, ARGMOD(PMC *key), ARGIN(STRING *value))
 PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
 PARROT_WARN_UNUSED_RESULT
-STRING * key_set_to_string(PARROT_INTERP, ARGIN_NULLOK(PMC *key))
+STRING * Parrot_key_set_to_string(PARROT_INTERP, ARGIN_NULLOK(PMC *key))
         __attribute__nonnull__(1);
 
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 PARROT_CAN_RETURN_NULL
-STRING * key_string(PARROT_INTERP, ARGIN(PMC *key))
+STRING * Parrot_key_string(PARROT_INTERP, ARGIN(PMC *key))
         __attribute__nonnull__(1)
         __attribute__nonnull__(2);
 
 PARROT_EXPORT
 PARROT_PURE_FUNCTION
 PARROT_WARN_UNUSED_RESULT
-INTVAL key_type(SHIM_INTERP, ARGIN(const PMC *key))
+INTVAL Parrot_key_type(SHIM_INTERP, ARGIN(const PMC *key))
         __attribute__nonnull__(2);
 
-#define ASSERT_ARGS_key_append __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_append __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(key1) \
     , PARROT_ASSERT_ARG(key2))
-#define ASSERT_ARGS_key_integer __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_integer __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(key))
-#define ASSERT_ARGS_key_mark __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_mark __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(key))
-#define ASSERT_ARGS_key_new __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_new __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp))
-#define ASSERT_ARGS_key_new_cstring __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_new_cstring __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp))
-#define ASSERT_ARGS_key_new_integer __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_new_integer __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp))
-#define ASSERT_ARGS_key_new_number __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_new_number __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp))
-#define ASSERT_ARGS_key_new_string __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_new_string __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(value))
-#define ASSERT_ARGS_key_next __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_next __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(key))
-#define ASSERT_ARGS_key_number __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_number __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(key))
-#define ASSERT_ARGS_key_pmc __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_pmc __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(key))
-#define ASSERT_ARGS_key_set_integer __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_set_integer __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(key))
-#define ASSERT_ARGS_key_set_number __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_set_number __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(key))
-#define ASSERT_ARGS_key_set_register __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_set_register __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(key))
-#define ASSERT_ARGS_key_set_string __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_set_string __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(key) \
     , PARROT_ASSERT_ARG(value))
-#define ASSERT_ARGS_key_set_to_string __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_set_to_string __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp))
-#define ASSERT_ARGS_key_string __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_string __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(key))
-#define ASSERT_ARGS_key_type __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+#define ASSERT_ARGS_Parrot_key_type __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(key))
 /* Don't modify between HEADERIZER BEGIN / HEADERIZER END.  Your changes will be lost. */
 /* HEADERIZER END: src/key.c */

--- a/include/parrot/pointer_array.h
+++ b/include/parrot/pointer_array.h
@@ -21,7 +21,7 @@ Lower bit in cell masked to indicate pointer-to-free-cell.
 
 /* Calculate size of chunk data     "header"  */
 #define CHUNK_SIZE 4096
-#define CELL_PER_CHUNK ((CHUNK_SIZE - 2 * sizeof(size_t) / sizeof (void *)))
+#define CELL_PER_CHUNK ((CHUNK_SIZE - 2 * sizeof(size_t)) / sizeof (void *))
 
 typedef struct Parrot_Pointer_Array_Chunk {
     size_t   num_free;
@@ -105,7 +105,7 @@ void Parrot_pa_remove(PARROT_INTERP,
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(self) \
     , PARROT_ASSERT_ARG(ptr))
-#define ASSERT_ARGS_Parrot_pa_is_owned __attribute__unused__ int _ASSERT_ARGS_C = (\
+#define ASSERT_ARGS_Parrot_pa_is_owned __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(interp) \
     , PARROT_ASSERT_ARG(self) \
     , PARROT_ASSERT_ARG(orig))

--- a/src/call/args.c
+++ b/src/call/args.c
@@ -1814,7 +1814,7 @@ clone_key_arg(PARROT_INTERP, ARGIN(PMC *key))
     if (key->vtable->base_type != enum_class_Key)
         return key;
 
-    for (t = key; t; t=key_next(interp, t)) {
+    for (t = key; t; t=Parrot_key_next(interp, t)) {
         /* register keys have to be cloned */
         if (PObj_get_FLAGS(key) & KEY_register_FLAG) {
             return VTABLE_clone(interp, key);

--- a/src/dynpmc/subproxy.pmc
+++ b/src/dynpmc/subproxy.pmc
@@ -39,7 +39,7 @@ pmclass SubProxy dynpmc extends Sub auto_attrs {
             if (!file)
                 Parrot_ex_throw_from_c_args(INTERP, NULL, 1, "SubProxy: no file");
 
-            sub_pmc = key_next(INTERP, key);
+            sub_pmc = Parrot_key_next(INTERP, key);
             if (!sub_pmc)
                 Parrot_ex_throw_from_c_args(INTERP, NULL, 1, "SubProxy: no sub");
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -1814,18 +1814,18 @@ hash_key_from_pmc(PARROT_INTERP, ARGIN(const Hash *hash), ARGIN(PMC *key))
         {
             /* Extract real value from Key (and box it if nessary) */
             if (key->vtable->base_type == enum_class_Key)
-                switch (key_type(interp, key)) {
+                switch (Parrot_key_type(interp, key)) {
                   case KEY_integer_FLAG:
-                    key = get_integer_pmc(interp, key_integer(interp, key));
+                    key = get_integer_pmc(interp, Parrot_key_integer(interp, key));
                     break;
                   case KEY_string_FLAG:
-                    key = get_string_pmc(interp, key_string(interp, key));
+                    key = get_string_pmc(interp, Parrot_key_string(interp, key));
                     break;
                   case KEY_number_FLAG:
-                    key = get_number_pmc(interp, key_number(interp, key));
+                    key = get_number_pmc(interp, Parrot_key_number(interp, key));
                     break;
                   case KEY_pmc_FLAG:
-                    key = key_pmc(interp, key);
+                    key = Parrot_key_pmc(interp, key);
                     break;
                   default:
                     /* It's impossible if Keys are same (and they are not) */

--- a/src/key.c
+++ b/src/key.c
@@ -27,7 +27,7 @@ The base vtable calling functions.
 
 /*
 
-=item C<PMC * key_new(PARROT_INTERP)>
+=item C<PMC * Parrot_key_new(PARROT_INTERP)>
 
 Returns a new C<Key> PMC.
 
@@ -39,16 +39,16 @@ PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
 PARROT_WARN_UNUSED_RESULT
 PMC *
-key_new(PARROT_INTERP)
+Parrot_key_new(PARROT_INTERP)
 {
-    ASSERT_ARGS(key_new)
+    ASSERT_ARGS(Parrot_key_new)
     return Parrot_pmc_new(interp, enum_class_Key);
 }
 
 
 /*
 
-=item C<PMC * key_new_integer(PARROT_INTERP, INTVAL value)>
+=item C<PMC * Parrot_key_new_integer(PARROT_INTERP, INTVAL value)>
 
 Returns a new integer C<Key> PMC with value C<value>.
 
@@ -60,9 +60,9 @@ PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
 PARROT_WARN_UNUSED_RESULT
 PMC *
-key_new_integer(PARROT_INTERP, INTVAL value)
+Parrot_key_new_integer(PARROT_INTERP, INTVAL value)
 {
-    ASSERT_ARGS(key_new_integer)
+    ASSERT_ARGS(Parrot_key_new_integer)
     PMC * const key = Parrot_pmc_new(interp, enum_class_Key);
 
     PObj_get_FLAGS(key) |= KEY_integer_FLAG;
@@ -74,7 +74,7 @@ key_new_integer(PARROT_INTERP, INTVAL value)
 
 /*
 
-=item C<PMC * key_new_number(PARROT_INTERP, FLOATVAL value)>
+=item C<PMC * Parrot_key_new_number(PARROT_INTERP, FLOATVAL value)>
 
 Returns a new number C<Key> PMC with value C<value>.
 
@@ -86,9 +86,9 @@ PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
 PARROT_WARN_UNUSED_RESULT
 PMC *
-key_new_number(PARROT_INTERP, FLOATVAL value)
+Parrot_key_new_number(PARROT_INTERP, FLOATVAL value)
 {
-    ASSERT_ARGS(key_new_number)
+    ASSERT_ARGS(Parrot_key_new_number)
     PMC * const key = Parrot_pmc_new(interp, enum_class_Key);
 
     PObj_get_FLAGS(key) |= KEY_number_FLAG;
@@ -100,7 +100,7 @@ key_new_number(PARROT_INTERP, FLOATVAL value)
 
 /*
 
-=item C<PMC * key_new_string(PARROT_INTERP, STRING *value)>
+=item C<PMC * Parrot_key_new_string(PARROT_INTERP, STRING *value)>
 
 Returns a new string C<Key> PMC with value C<value>.
 
@@ -112,9 +112,9 @@ PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
 PARROT_WARN_UNUSED_RESULT
 PMC *
-key_new_string(PARROT_INTERP, ARGIN(STRING *value))
+Parrot_key_new_string(PARROT_INTERP, ARGIN(STRING *value))
 {
-    ASSERT_ARGS(key_new_string)
+    ASSERT_ARGS(Parrot_key_new_string)
     PMC * const key = Parrot_pmc_new(interp, enum_class_Key);
 
     PObj_get_FLAGS(key) |= KEY_string_FLAG;
@@ -126,7 +126,7 @@ key_new_string(PARROT_INTERP, ARGIN(STRING *value))
 
 /*
 
-=item C<PMC * key_new_cstring(PARROT_INTERP, const char *value)>
+=item C<PMC * Parrot_key_new_cstring(PARROT_INTERP, const char *value)>
 
 Returns a new string C<Key> PMC with value C<value> converted to a
 C<STRING>.
@@ -139,15 +139,15 @@ PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
 PARROT_WARN_UNUSED_RESULT
 PMC *
-key_new_cstring(PARROT_INTERP, ARGIN_NULLOK(const char *value))
+Parrot_key_new_cstring(PARROT_INTERP, ARGIN_NULLOK(const char *value))
 {
-    ASSERT_ARGS(key_new_cstring)
-    return key_new_string(interp, Parrot_str_new(interp, value, 0));
+    ASSERT_ARGS(Parrot_key_new_cstring)
+    return Parrot_key_new_string(interp, Parrot_str_new(interp, value, 0));
 }
 
 /*
 
-=item C<void key_set_integer(PARROT_INTERP, PMC *key, INTVAL value)>
+=item C<void Parrot_key_set_integer(PARROT_INTERP, PMC *key, INTVAL value)>
 
 Set the integer C<value> in C<key>.
 
@@ -157,9 +157,9 @@ Set the integer C<value> in C<key>.
 
 PARROT_EXPORT
 void
-key_set_integer(PARROT_INTERP, ARGMOD(PMC *key), INTVAL value)
+Parrot_key_set_integer(PARROT_INTERP, ARGMOD(PMC *key), INTVAL value)
 {
-    ASSERT_ARGS(key_set_integer)
+    ASSERT_ARGS(Parrot_key_set_integer)
     PObj_get_FLAGS(key) &= ~KEY_type_FLAGS;
     PObj_get_FLAGS(key) |=  KEY_integer_FLAG;
     SETATTR_Key_int_key(interp, key, value);
@@ -170,8 +170,8 @@ key_set_integer(PARROT_INTERP, ARGMOD(PMC *key), INTVAL value)
 
 /*
 
-=item C<void key_set_register(PARROT_INTERP, PMC *key, INTVAL value, INTVAL
-flag)>
+=item C<void Parrot_key_set_register(PARROT_INTERP, PMC *key, INTVAL value,
+INTVAL flag)>
 
 Set the register C<value> in C<key>.
 
@@ -181,9 +181,9 @@ Set the register C<value> in C<key>.
 
 PARROT_EXPORT
 void
-key_set_register(PARROT_INTERP, ARGMOD(PMC *key), INTVAL value, INTVAL flag)
+Parrot_key_set_register(PARROT_INTERP, ARGMOD(PMC *key), INTVAL value, INTVAL flag)
 {
-    ASSERT_ARGS(key_set_register)
+    ASSERT_ARGS(Parrot_key_set_register)
     PObj_get_FLAGS(key) &= ~KEY_type_FLAGS;
     PObj_get_FLAGS(key) |=  KEY_register_FLAG | flag;
     SETATTR_Key_int_key(interp, key, value);
@@ -194,7 +194,7 @@ key_set_register(PARROT_INTERP, ARGMOD(PMC *key), INTVAL value, INTVAL flag)
 
 /*
 
-=item C<void key_set_number(PARROT_INTERP, PMC *key, FLOATVAL value)>
+=item C<void Parrot_key_set_number(PARROT_INTERP, PMC *key, FLOATVAL value)>
 
 Set the number C<value> in C<key>.
 
@@ -204,9 +204,9 @@ Set the number C<value> in C<key>.
 
 PARROT_EXPORT
 void
-key_set_number(PARROT_INTERP, ARGMOD(PMC *key), FLOATVAL value)
+Parrot_key_set_number(PARROT_INTERP, ARGMOD(PMC *key), FLOATVAL value)
 {
-    ASSERT_ARGS(key_set_number)
+    ASSERT_ARGS(Parrot_key_set_number)
     PObj_get_FLAGS(key) &= ~KEY_type_FLAGS;
     PObj_get_FLAGS(key) |=  KEY_number_FLAG;
     SETATTR_Key_num_key(interp, key, value);
@@ -217,7 +217,7 @@ key_set_number(PARROT_INTERP, ARGMOD(PMC *key), FLOATVAL value)
 
 /*
 
-=item C<void key_set_string(PARROT_INTERP, PMC *key, STRING *value)>
+=item C<void Parrot_key_set_string(PARROT_INTERP, PMC *key, STRING *value)>
 
 Set the string C<value> in C<key>.
 
@@ -227,9 +227,9 @@ Set the string C<value> in C<key>.
 
 PARROT_EXPORT
 void
-key_set_string(PARROT_INTERP, ARGMOD(PMC *key), ARGIN(STRING *value))
+Parrot_key_set_string(PARROT_INTERP, ARGMOD(PMC *key), ARGIN(STRING *value))
 {
-    ASSERT_ARGS(key_set_string)
+    ASSERT_ARGS(Parrot_key_set_string)
     PObj_get_FLAGS(key) &= ~KEY_type_FLAGS;
     PObj_get_FLAGS(key) |=  KEY_string_FLAG;
     SETATTR_Key_str_key(interp, key, value);
@@ -239,7 +239,7 @@ key_set_string(PARROT_INTERP, ARGMOD(PMC *key), ARGIN(STRING *value))
 
 /*
 
-=item C<INTVAL key_type(PARROT_INTERP, const PMC *key)>
+=item C<INTVAL Parrot_key_type(PARROT_INTERP, const PMC *key)>
 
 Returns the type of C<key>.
 
@@ -251,16 +251,16 @@ PARROT_EXPORT
 PARROT_PURE_FUNCTION
 PARROT_WARN_UNUSED_RESULT
 INTVAL
-key_type(SHIM_INTERP, ARGIN(const PMC *key))
+Parrot_key_type(SHIM_INTERP, ARGIN(const PMC *key))
 {
-    ASSERT_ARGS(key_type)
+    ASSERT_ARGS(Parrot_key_type)
     return (PObj_get_FLAGS(key) & KEY_type_FLAGS) & ~KEY_register_FLAG;
 }
 
 
 /*
 
-=item C<INTVAL key_integer(PARROT_INTERP, PMC *key)>
+=item C<INTVAL Parrot_key_integer(PARROT_INTERP, PMC *key)>
 
 Translates a key value into an integer.
 Takes an interpreter name and pointer to a key.
@@ -273,9 +273,9 @@ Returns an integer value corresponding to the key.
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 INTVAL
-key_integer(PARROT_INTERP, ARGIN(PMC *key))
+Parrot_key_integer(PARROT_INTERP, ARGIN(PMC *key))
 {
-    ASSERT_ARGS(key_integer)
+    ASSERT_ARGS(Parrot_key_integer)
     INTVAL   int_key;
     STRING  *str_key;
     FLOATVAL num_key;
@@ -324,7 +324,7 @@ key_integer(PARROT_INTERP, ARGIN(PMC *key))
 
 /*
 
-=item C<FLOATVAL key_number(PARROT_INTERP, PMC *key)>
+=item C<FLOATVAL Parrot_key_number(PARROT_INTERP, PMC *key)>
 
 Translates a key value into a number.
 Takes an interpreter name and pointer to a key.
@@ -338,9 +338,9 @@ Throws an exception if the key is not a valid number.
 PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 FLOATVAL
-key_number(PARROT_INTERP, ARGIN(PMC *key))
+Parrot_key_number(PARROT_INTERP, ARGIN(PMC *key))
 {
-    ASSERT_ARGS(key_number)
+    ASSERT_ARGS(Parrot_key_number)
     INTVAL   int_key;
     FLOATVAL num_key;
 
@@ -369,7 +369,7 @@ key_number(PARROT_INTERP, ARGIN(PMC *key))
 
 /*
 
-=item C<STRING * key_string(PARROT_INTERP, PMC *key)>
+=item C<STRING * Parrot_key_string(PARROT_INTERP, PMC *key)>
 
 Translates a key value into a string.  Takes an interpreter name and pointer to
 a key.  Returns a string value corresponding to the key.
@@ -382,9 +382,9 @@ PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 PARROT_CAN_RETURN_NULL
 STRING *
-key_string(PARROT_INTERP, ARGIN(PMC *key))
+Parrot_key_string(PARROT_INTERP, ARGIN(PMC *key))
 {
-    ASSERT_ARGS(key_string)
+    ASSERT_ARGS(Parrot_key_string)
 
     switch (PObj_get_FLAGS(key) & KEY_type_FLAGS) {
         /* remember to COW strings instead of returning them directly */
@@ -441,7 +441,7 @@ key_string(PARROT_INTERP, ARGIN(PMC *key))
 
 /*
 
-=item C<PMC * key_pmc(PARROT_INTERP, PMC *key)>
+=item C<PMC * Parrot_key_pmc(PARROT_INTERP, PMC *key)>
 
 These functions return the integer/number/string/PMC values of C<key> if
 possible. Otherwise they throw exceptions.
@@ -454,9 +454,9 @@ PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
 PARROT_WARN_UNUSED_RESULT
 PMC *
-key_pmc(PARROT_INTERP, ARGIN(PMC *key))
+Parrot_key_pmc(PARROT_INTERP, ARGIN(PMC *key))
 {
-    ASSERT_ARGS(key_pmc)
+    ASSERT_ARGS(Parrot_key_pmc)
     INTVAL int_key;
 
     switch (PObj_get_FLAGS(key) & KEY_type_FLAGS) {
@@ -471,7 +471,7 @@ key_pmc(PARROT_INTERP, ARGIN(PMC *key))
 
 /*
 
-=item C<PMC * key_next(PARROT_INTERP, PMC *key)>
+=item C<PMC * Parrot_key_next(PARROT_INTERP, PMC *key)>
 
 Returns the next key if C<key> is in a sequence of linked keys.
 
@@ -483,9 +483,9 @@ PARROT_EXPORT
 PARROT_CAN_RETURN_NULL
 PARROT_WARN_UNUSED_RESULT
 PMC *
-key_next(PARROT_INTERP, ARGIN(PMC *key))
+Parrot_key_next(PARROT_INTERP, ARGIN(PMC *key))
 {
-    ASSERT_ARGS(key_next)
+    ASSERT_ARGS(Parrot_key_next)
 
     if (VTABLE_isa(interp, key, CONST_STRING(interp, "Key"))) {
         PMC *next_key;
@@ -499,7 +499,7 @@ key_next(PARROT_INTERP, ARGIN(PMC *key))
 
 /*
 
-=item C<PMC * key_append(PARROT_INTERP, PMC *key1, PMC *key2)>
+=item C<PMC * Parrot_key_append(PARROT_INTERP, PMC *key1, PMC *key2)>
 
 Appends C<key2> to C<key1>.
 
@@ -516,9 +516,9 @@ PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
 PARROT_IGNORABLE_RESULT
 PMC *
-key_append(PARROT_INTERP, ARGMOD(PMC *key1), ARGIN(PMC *key2))
+Parrot_key_append(PARROT_INTERP, ARGMOD(PMC *key1), ARGIN(PMC *key2))
 {
-    ASSERT_ARGS(key_append)
+    ASSERT_ARGS(Parrot_key_append)
     PMC *tail = key1;
     PMC *tail_next;
 
@@ -537,7 +537,7 @@ key_append(PARROT_INTERP, ARGMOD(PMC *key1), ARGIN(PMC *key2))
 
 /*
 
-=item C<void key_mark(PARROT_INTERP, PMC *key)>
+=item C<void Parrot_key_mark(PARROT_INTERP, PMC *key)>
 
 Marks C<key> as live.
 
@@ -547,9 +547,9 @@ Marks C<key> as live.
 
 PARROT_EXPORT
 void
-key_mark(PARROT_INTERP, ARGIN(PMC *key))
+Parrot_key_mark(PARROT_INTERP, ARGIN(PMC *key))
 {
-    ASSERT_ARGS(key_mark)
+    ASSERT_ARGS(Parrot_key_mark)
     PMC          *next_key;
     const UINTVAL flags = PObj_get_FLAGS(key) & KEY_type_FLAGS;
 
@@ -570,7 +570,7 @@ key_mark(PARROT_INTERP, ARGIN(PMC *key))
 
 /*
 
-=item C<STRING * key_set_to_string(PARROT_INTERP, PMC *key)>
+=item C<STRING * Parrot_key_set_to_string(PARROT_INTERP, PMC *key)>
 
 Translates a series of key values into strings, quoted or bracketed if
 appropriate.  Takes an interpreter name and pointer to a key.  Returns a
@@ -584,9 +584,9 @@ PARROT_EXPORT
 PARROT_CANNOT_RETURN_NULL
 PARROT_WARN_UNUSED_RESULT
 STRING *
-key_set_to_string(PARROT_INTERP, ARGIN_NULLOK(PMC *key))
+Parrot_key_set_to_string(PARROT_INTERP, ARGIN_NULLOK(PMC *key))
 {
-    ASSERT_ARGS(key_set_to_string)
+    ASSERT_ARGS(Parrot_key_set_to_string)
     STRING * const semicolon = CONST_STRING(interp, " ; ");
     STRING * const quote     = CONST_STRING(interp, "'");
     STRING * const P         = CONST_STRING(interp, "P");

--- a/src/packdump.c
+++ b/src/packdump.c
@@ -233,13 +233,13 @@ PackFile_Constant_dump_pmc(PARROT_INTERP, ARGIN(const PackFile_ConstTable *ct),
               case KEY_integer_FLAG:
                 Parrot_io_printf(interp, "        TYPE        => INTEGER\n");
                 Parrot_io_printf(interp, "        DATA        => %ld\n",
-                            key_integer(interp, key));
+                            Parrot_key_integer(interp, key));
                 Parrot_io_printf(interp, "       },\n");
                 break;
               case KEY_number_FLAG:
                 {
                     size_t ct_index;
-                    FLOATVAL n = key_number(interp, key);
+                    FLOATVAL n = Parrot_key_number(interp, key);
 
                     Parrot_io_printf(interp, "        TYPE        => NUMBER\n");
                     ct_index = PackFile_ConstTable_rlookup_num(interp, ct, n);
@@ -253,7 +253,7 @@ PackFile_Constant_dump_pmc(PARROT_INTERP, ARGIN(const PackFile_ConstTable *ct),
               case KEY_string_FLAG:
                 {
                     size_t ct_index;
-                    STRING *s = key_string(interp, key);
+                    STRING *s = Parrot_key_string(interp, key);
 
                     Parrot_io_printf(interp, "        TYPE        => STRING\n");
                     ct_index = PackFile_ConstTable_rlookup_str(interp, ct, s);
@@ -342,7 +342,7 @@ PackFile_Constant_dump_pmc(PARROT_INTERP, ARGIN(const PackFile_ConstTable *ct),
                             break;
                         case enum_class_Key:
                             namespace_description =
-                                key_set_to_string(interp, sub->namespace_name);
+                                Parrot_key_set_to_string(interp, sub->namespace_name);
                             break;
                         default:
                             namespace_description = sub->namespace_name->vtable->whoami;

--- a/src/pmc/default.pmc
+++ b/src/pmc/default.pmc
@@ -20,7 +20,7 @@ generated from F<src/vtable.tbl> by F<tools/build/pmc2c.pl>.
 
 */
 
-#define INT2KEY(i, k) key_new_integer((i), (k))
+#define INT2KEY(i, k) Parrot_key_new_integer((i), (k))
 
 /* HEADERIZER HFILE: none */
 /* HEADERIZER BEGIN: static */

--- a/src/pmc/fixedpmcarray.pmc
+++ b/src/pmc/fixedpmcarray.pmc
@@ -344,7 +344,7 @@ Returns the PMC value of the element at index C<*key>.
 
     VTABLE PMC *get_pmc_keyed(PMC *key) {
         const INTVAL k        = VTABLE_get_integer(INTERP, key);
-        PMC   * const nextkey = key_next(INTERP, key);
+        PMC   * const nextkey = Parrot_key_next(INTERP, key);
         PMC   *box;
 
         if (!nextkey)
@@ -485,7 +485,7 @@ C<value>.
 
     VTABLE void set_number_keyed(PMC *key, FLOATVAL value) {
         const INTVAL k        = VTABLE_get_integer(INTERP, key);
-        PMC   * const nextkey = key_next(INTERP, key);
+        PMC   * const nextkey = Parrot_key_next(INTERP, key);
 
         if (nextkey == NULL) {
             SELF.set_number_keyed_int(k, value);
@@ -573,7 +573,7 @@ Sets the PMC at index C<key> to C<value>.
 
     VTABLE void set_pmc_keyed(PMC *key, PMC *value) {
         const INTVAL k = VTABLE_get_integer(INTERP, key);
-        PMC   *nextkey = key_next(INTERP, key);
+        PMC   *nextkey = Parrot_key_next(INTERP, key);
 
         if (!nextkey) {
             SELF.set_pmc_keyed_int(k, value);

--- a/src/pmc/hash.pmc
+++ b/src/pmc/hash.pmc
@@ -461,7 +461,7 @@ Returns the integer value for the element at C<*key>.
         if (!b)
             return 0;
 
-        key = key_next(INTERP, key);
+        key = Parrot_key_next(INTERP, key);
 
         /* Stop recursion. This is last step */
         if (!key)
@@ -493,7 +493,7 @@ Returns the integer value for the element at C<*key>.
                 EXCEPTION_INVALID_OPERATION,
                 "Used non-constant PMC key in constant hash.");
 
-        key = key_next(INTERP, key);
+        key = Parrot_key_next(INTERP, key);
 
         if (!key) {
             parrot_hash_put(INTERP, hash, hash_key,
@@ -587,7 +587,7 @@ Returns the floating-point value for the element at C<*key>.
         if (!b)
             return 0.0;
 
-        key = key_next(INTERP, key);
+        key = Parrot_key_next(INTERP, key);
 
         if (!key)
             return hash_value_to_number(INTERP, hash, b->value);
@@ -651,7 +651,7 @@ Returns the string value for the element at C<*key>.
         if (!b)
             return CONST_STRING(INTERP, "");
 
-        key = key_next(INTERP, key);
+        key = Parrot_key_next(INTERP, key);
 
         /* Stop recursion. This is last step */
         if (!key)
@@ -688,7 +688,7 @@ Returns the string value for the element at C<*key>.
                     "Used non-constant STRING value in constant hash.");
         }
 
-        key = key_next(INTERP, key);
+        key = Parrot_key_next(INTERP, key);
 
         if (!key) {
             parrot_hash_put(INTERP, hash, hash_key,
@@ -799,7 +799,7 @@ Returns the PMC value for the element at C<*key>.
         if (!b)
             return PMCNULL;
 
-        key = key_next(INTERP, key);
+        key = Parrot_key_next(INTERP, key);
 
         /* Stop recursion. This is last step */
         if (!key)
@@ -831,7 +831,7 @@ Returns the PMC value for the element at C<*key>.
                 EXCEPTION_INVALID_OPERATION,
                 "Used non-constant PMC key in constant hash.");
 
-        key = key_next(INTERP, key);
+        key = Parrot_key_next(INTERP, key);
 
         if (!key) {
             parrot_hash_put(INTERP, hash, hash_key,
@@ -894,7 +894,7 @@ Sets C<value> as the value for C<*key>.
                     "Used non-constant PMC value in constant hash.");
         }
 
-        key = key_next(INTERP, key);
+        key = Parrot_key_next(INTERP, key);
 
         if (!key) {
             parrot_hash_put(INTERP, hash, hash_key, value);
@@ -972,7 +972,7 @@ Returns whether a key C<*key> exists in the hash.
         if (!b)
             return 0;
 
-        key = key_next(INTERP, key);
+        key = Parrot_key_next(INTERP, key);
 
         /* lookup stops here */
         if (!key)
@@ -1025,7 +1025,7 @@ Returns whether the value for C<*key> is defined.
         if (!b)
             return 0;
 
-        key = key_next(INTERP, key);
+        key = Parrot_key_next(INTERP, key);
 
         if (!key)
             return VTABLE_defined(INTERP, hash_value_to_pmc(INTERP, h, b->value));
@@ -1070,7 +1070,7 @@ Deletes the element associated with C<*key>.
         if (!b)
             return;
 
-        key = key_next(INTERP, key);
+        key = Parrot_key_next(INTERP, key);
 
         if (!key) {
             parrot_hash_delete(INTERP, h, sx);

--- a/src/pmc/imageiosize.pmc
+++ b/src/pmc/imageiosize.pmc
@@ -201,7 +201,7 @@ Pushes the string C<*v> onto the end of the image.
     VTABLE void push_string(STRING *v) {
         if (PObj_flag_TEST(private1, SELF)) {
             /* store a reference to constant table entry of string */
-            PMC *v_pmc = key_new_string(interp, v);
+            PMC *v_pmc = Parrot_key_new_string(interp, v);
             PackFile_ConstTable *table = PARROT_IMAGEIOSIZE(SELF)->pf_ct;
             int idx = PackFile_ConstTable_rlookup_str(INTERP, table, v);
 

--- a/src/pmc/key.pmc
+++ b/src/pmc/key.pmc
@@ -65,15 +65,15 @@ Creates and returns a clone of the key.
             switch (PObj_get_FLAGS(key) & KEY_type_FLAGS) {
               case KEY_integer_FLAG:
               case KEY_integer_FLAG | KEY_register_FLAG:
-                key_set_integer(INTERP, dkey, key_integer(INTERP, key));
+                Parrot_key_set_integer(INTERP, dkey, Parrot_key_integer(INTERP, key));
                 break;
               case KEY_number_FLAG:
               case KEY_number_FLAG | KEY_register_FLAG:
-                key_set_number(INTERP, dkey, key_number(INTERP, key));
+                Parrot_key_set_number(INTERP, dkey, Parrot_key_number(INTERP, key));
                 break;
               case KEY_string_FLAG:
               case KEY_string_FLAG | KEY_register_FLAG:
-                key_set_string(INTERP, dkey, VTABLE_get_string(INTERP, key));
+                Parrot_key_set_string(INTERP, dkey, VTABLE_get_string(INTERP, key));
                 break;
               case KEY_pmc_FLAG:
               case KEY_pmc_FLAG | KEY_register_FLAG:
@@ -83,11 +83,11 @@ Creates and returns a clone of the key.
                 break;
             }
 
-            key = key_next(INTERP, key);
+            key = Parrot_key_next(INTERP, key);
 
             if (key) {
-                PMC * const p = key_new(INTERP);
-                key_append(INTERP, dkey, p);
+                PMC * const p = Parrot_key_new(INTERP);
+                Parrot_key_append(INTERP, dkey, p);
                 dkey = p;
             }
         }
@@ -106,7 +106,7 @@ Marks the key as live.
 */
 
     VTABLE void mark() {
-        key_mark(INTERP, SELF);
+        Parrot_key_mark(INTERP, SELF);
     }
 
 /*
@@ -120,7 +120,7 @@ Returns the integer value of the key.
 */
 
     VTABLE INTVAL get_integer() {
-        return key_integer(INTERP, SELF);
+        return Parrot_key_integer(INTERP, SELF);
     }
 
 /*
@@ -134,7 +134,7 @@ Returns the floating-point number value of the key.
 */
 
     VTABLE FLOATVAL get_number() {
-        return key_number(INTERP, SELF);
+        return Parrot_key_number(INTERP, SELF);
     }
 
 /*
@@ -148,9 +148,9 @@ Returns the Parrot string value of the key.
 */
 
     VTABLE STRING *get_string() {
-        /* key_string() is only useful if this PMC has a key type */
+        /* Parrot_key_string() is only useful if this PMC has a key type */
         if (PObj_get_FLAGS(SELF) & KEY_type_FLAGS)
-            return key_string(INTERP, SELF);
+            return Parrot_key_string(INTERP, SELF);
 
         return CONST_STRING(INTERP, "");
     }
@@ -166,7 +166,7 @@ Returns the PMC value of the key.
 */
 
     VTABLE PMC *get_pmc() {
-        return key_pmc(INTERP, SELF);
+        return Parrot_key_pmc(INTERP, SELF);
     }
 
 /*
@@ -178,7 +178,7 @@ Returns the PMC value of the key.
 */
 
     VTABLE void set_integer_native(INTVAL value) {
-        key_set_integer(INTERP, SELF, value);
+        Parrot_key_set_integer(INTERP, SELF, value);
     }
 
 /*
@@ -192,7 +192,7 @@ Sets the value of the key to C<value>.
 */
 
     VTABLE void set_number_native(FLOATVAL value) {
-        key_set_number(INTERP, SELF, value);
+        Parrot_key_set_number(INTERP, SELF, value);
     }
 
 /*
@@ -205,7 +205,7 @@ Sets the value of the key to C<value>.
 */
 
     VTABLE void set_string_native(STRING *value) {
-        key_set_string(INTERP, SELF, value);
+        Parrot_key_set_string(INTERP, SELF, value);
     }
 
 /*
@@ -238,7 +238,7 @@ Appends C<*value> to the key.
             Parrot_ex_throw_from_c_args(INTERP, NULL, EXCEPTION_INVALID_OPERATION,
                 "Can only push another Key onto a Key PMC.");
 
-        key_append(INTERP, SELF, value);
+        Parrot_key_append(INTERP, SELF, value);
     }
 
 /*
@@ -411,7 +411,7 @@ Called after the Key has been thawed: convert last PMC_NULL key to NULL.
     }
 
     VTABLE STRING* get_repr() {
-        return key_set_to_string(INTERP, SELF);
+        return Parrot_key_set_to_string(INTERP, SELF);
     }
 
 /*
@@ -422,7 +422,7 @@ Set key to hold particular register.
 =cut
 */
     METHOD set_register(INTVAL reg_no, INTVAL reg_type) {
-        key_set_register(INTERP, SELF, reg_no, reg_type);
+        Parrot_key_set_register(INTERP, SELF, reg_no, reg_type);
     }
 
 }

--- a/src/pmc/oplib.pmc
+++ b/src/pmc/oplib.pmc
@@ -72,7 +72,7 @@ pmclass OpLib auto_attrs {
     }
 
     VTABLE INTVAL get_integer_keyed(PMC *key) {
-        STRING *str_key = key_string(INTERP, key);
+        STRING *str_key = Parrot_key_string(INTERP, key);
         return SELF.get_integer_keyed_str(str_key);
     }
 

--- a/src/pmc/orderedhash.pmc
+++ b/src/pmc/orderedhash.pmc
@@ -376,7 +376,7 @@ Main set function.
         PMC *list_entry = VTABLE_get_pmc_keyed(INTERP, attrs->hash, key);
         if (!PMC_IS_NULL(list_entry)) {
             /* We have old entry. Just update value */
-            PMC * const nextkey = key_next(INTERP, key);
+            PMC * const nextkey = Parrot_key_next(INTERP, key);
             if (nextkey) {
                 /* XXX old_value is unused.  Should we be storing this at all? */
                 PMC * const old_value = VTABLE_get_pmc_keyed_int(INTERP, list_entry,

--- a/src/pmc/parrotinterpreter.pmc
+++ b/src/pmc/parrotinterpreter.pmc
@@ -458,7 +458,7 @@ Introspection interface. C<key> can be:
     VTABLE PMC *get_pmc_keyed(PMC *key) {
         PMC    *nextkey;
         STRING *outer = NULL;
-        STRING *item  = key_string(INTERP, key);
+        STRING *item  = Parrot_key_string(INTERP, key);
         STRING *name  = CONST_STRING(INTERP, "globals");
         int     level = 0;
 
@@ -471,7 +471,7 @@ Introspection interface. C<key> can be:
 
         if (STRING_equal(INTERP, item, name)) {
             outer   = item;
-            nextkey = key_next(INTERP, key);
+            nextkey = Parrot_key_next(INTERP, key);
 
             if (nextkey && (PObj_get_FLAGS(nextkey) & KEY_string_FLAG)) {
                 key  = nextkey;
@@ -479,7 +479,7 @@ Introspection interface. C<key> can be:
             }
         }
 
-        nextkey = key_next(INTERP, key);
+        nextkey = Parrot_key_next(INTERP, key);
 
         if (nextkey)
             level = VTABLE_get_integer(INTERP, nextkey);

--- a/src/pmc/unmanagedstruct.pmc
+++ b/src/pmc/unmanagedstruct.pmc
@@ -282,7 +282,7 @@ char_offset_key(PARROT_INTERP, ARGIN(PMC *pmc), ARGIN(PMC *key), ARGOUT(int *typ
 #endif
 
     ix   = key_2_idx(interp, pmc, key);
-    next = key_next(interp, key);
+    next = Parrot_key_next(interp, key);
     p    = char_offset_int(interp, pmc, ix, type);
     ix  *= 3;
 
@@ -314,8 +314,8 @@ char_offset_key(PARROT_INTERP, ARGIN(PMC *pmc), ARGIN(PMC *key), ARGOUT(int *typ
 
         /* array of structs */
         if (max > 1) {
-            if (key_next(interp, next))
-                next = key_next(interp, next);
+            if (Parrot_key_next(interp, next))
+                next = Parrot_key_next(interp, next);
 
             offs = VTABLE_get_integer(interp, init);
 

--- a/src/runcore/trace.c
+++ b/src/runcore/trace.c
@@ -218,7 +218,7 @@ trace_key_dump(PARROT_INTERP, ARGIN(PMC *key))
             break;
           case KEY_string_FLAG:
             {
-            const STRING * const s = key_string(interp, key);
+            const STRING * const s = Parrot_key_string(interp, key);
             STRING * const escaped = Parrot_str_escape_truncate(interp, s, 20);
 
             if (escaped)


### PR DESCRIPTION
I'm the Google Code-In studient who claimed this task (http://www.google-melange.com/gci/task/show/google/gci2010/parrot_perl_foundations/t129035398267).
So I send this pull request, if you see a problem, contact me :)
