### PR TITLE
Fixing documentation

### DIFF
--- a/src/pmc/handle.pmc
+++ b/src/pmc/handle.pmc
@@ -71,7 +71,7 @@ subtypes that are or can be tty.
 
 =item C<METHOD get_fd()>
 
-Retrieve the integer file descriptor for the FileHandle (only available on
+Retrieve the integer file descriptor for the Handle (only available on
 platforms that use integer file descriptors).
 
 =cut


### PR DESCRIPTION
I did a GCI task that requested me to move get_fd() from FileHandle to Handle and when I 
copied and pasted the code (along with the documentation) I forgot to change a word.
