### PR TITLE
Increase string.pmc test coverage

### DIFF
--- a/t/pmc/string.t
+++ b/t/pmc/string.t
@@ -18,7 +18,7 @@ Tests the C<String> PMC.
 .sub main :main
     .include 'test_more.pir'
 
-    plan(136)
+    plan(148)
 
     set_or_get_strings()
     setting_integers()
@@ -32,15 +32,18 @@ Tests the C<String> PMC.
     test_if_string()
     test_concat()
     test_concat_without_defining_dest()
+    test_cmp_num()
     test_cmp()
     cmp_with_integer()
     test_substr()
+    test_eq_num()
     test_eq_str()
     test_ne_str()
     check_whether_interface_is_done()
     test_clone()
     test_set_px_i()
     test_set_px_s()
+    test_set_bool()
     test_string_replace()
     set_i0__p0__string_to_int()
     test_string_trans()
@@ -63,6 +66,7 @@ Tests the C<String> PMC.
 
 .sub set_or_get_strings
         new $P0, ['String']
+        new $P1, ['Boolean']
 
         set $P0, "foo"
         set $S0, $P0
@@ -87,6 +91,11 @@ Tests the C<String> PMC.
         set $P0, "0xFFFFFF"
         set $S0, $P0
         is( $S0, "0xFFFFFF", 'String obj set with literal hex string' )
+        
+        new $P1, ['Float']
+        set $P1, 3.14159
+        setref $P0, $P1
+        is( $P0, "3.14159", 'String obj set with Float PMC' )
 
         null $S0
         set $P0, $S0
@@ -366,6 +375,28 @@ TRUE5:  nok( $I0, 'uninitialized String is false' )
     is( $I0, "-1", 'cmp "abcde", "abc" = -1' )
 .end
 
+.sub test_cmp_num
+    new $P1, ['String']
+    new $P2, ['Integer']
+    set $P1, "10"
+    set $P2, 10
+    
+    cmp_num $I0, $P1, $P2
+    is( $I0, 0, 'cmp_num "10"(String PMC), 10(Integer PMC) = 0' )
+    
+    set $P2, 20
+    cmp_num $I0, $P1, $P2
+    is( $I0, -1, 'cmp_num "10", 20 = -1' )
+    
+    set $P2, 5
+    cmp_num $I0, $P1, $P2
+    is( $I0, 1, 'cmp_num "10", 5 = 1' )
+    
+    set $P1, "asd"
+    cmp_num $I0, $P1, $P2
+    is( $I0, -1, 'cmp_num "asd", 5 = -1' )
+.end
+
 .sub cmp_with_integer
     new $P1, ['Integer']
     new $P2, ['String']
@@ -411,6 +442,30 @@ TRUE5:  nok( $I0, 'uninitialized String is false' )
     is( $S2, ' is',               'start from the end' )
     is( $S3, " a test\n",         'valid offset, but length > string length' )
     is( $P0, "This is a test\n",  'original is unmodified' )
+.end
+
+.sub test_eq_num
+        new $P1, ['String']
+        new $P2, ['Float']
+        set $P1, "124"
+        set $P2, 124
+        
+        set $I0, 1
+        eq_num $P2, $P1, OK1
+        set $I0, 0
+OK1:    ok( $I0, 'eq_num "124"(String), 124(Float) -> true' )
+
+        set $P2, 124.2
+        set $I0, 1
+        eq_num $P2, $P1, OK2
+        set $I0, 0
+OK2:    nok( $I0, 'eq_num "124"(String), 124.2(Float) -> false' )
+
+        set $P2, 0
+        set $I0, 1
+        eq_num $P1, $P2, OK3
+        set $I0, 0
+OK3:    nok( $I0, 'eq_num 0(Float), "124"(String) -> false' )
 .end
 
 .sub test_eq_str
@@ -507,6 +562,25 @@ OK4:    ok( $I0, 'ne_str "0(Integer), "ABC" -> true' )
   set $P0, "abcdef\n"
   set $P0[2], "AB"
   is( $P0, "abABef\n", 'set p[x] = string' )
+.end
+
+.sub test_set_bool
+    new $P0, ['String']
+    
+    set $P0, "1"
+    not $P0
+    is( $P0, "0", 'not "1" = "0"' )
+    
+    not $P0
+    is( $P0, "1", 'not "0" = "1"' )
+    
+    set $P0, "false"
+    not $P0
+    is( $P0, "0", 'not "false" = "0"' )
+    
+    set $P0, 0
+    not $P0
+    is( $P0, "1", 'not 0 = "1"' )
 .end
 
 .sub test_string_replace


### PR DESCRIPTION
As part of a GCI task, I've added additional tests to <code>t/pmc/string.t</code> to increase the code coverage by roughly 8%, from 83% to 91%.
