### PR TITLE
Increase code coverage of the Complex PMC by 10%

### DIFF
--- a/t/pmc/complex.t
+++ b/t/pmc/complex.t
@@ -835,6 +835,25 @@ handler:
     todo( $I0, $S4 )
 .endm
 
+.macro complex_pow_todo( val, res, pow, todo )
+    $P1 = new ['Complex']
+    $P2 = new ['Complex']
+    set $P1, .val
+
+    set $S0, .val
+    set $S1, .res
+    set $S2, .pow
+
+    $P2 = $P1. 'pow'($S2)
+    $S3 = sprintf "%f%+fi", $P2
+
+    concat $S4, $S0, " ^ "
+    concat $S4, $S4, $S2
+
+    $I0 = iseq $S1, $S3
+    todo( $I0, $S4 )
+.endm
+
 .sub ln_of_complex_numbers
     .complex_op_is("-2+0i", "0.693147+3.141593i", 'ln' )
     .complex_op_is("-1+0i", "0.000000+3.141593i", 'ln' )


### PR DESCRIPTION
GCI Task: http://www.google-melange.com/gci/task/show/google/gci2010/parrot_perl_foundations/t129193205977
http://www.google-melange.com/gci/task/show/google/gci2010/parrot_perl_foundations/t129460296319

Hello,

I have found some problems, so I filled a bug on Trac: http://trac.parrot.org/parrot/ticket/1891.

After I wrote all my tests, I saw that there was a already written test (sinh_of_complex_numbers, on t/pmc/complex.t) that used a "if" to separate the tests that returned -0.0. Should I do the same with my tests?
UPDATE: already did that

Code coverage went from 76.3% to 97.1%! :)

Also, it would be nice to test it on win32 (see commits related to TT 313) to see if tests are passing.
Is there any build bot?

Your feedback is appreciated.
Thank you.
