### PR TITLE
GCI Task: Change names of 'make' coverage targets

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -201,7 +201,7 @@ disk, for later analysis by F<Parrot::Configure::Trace> methods.
 
 =item C<--coveragedir>
 
-In preparation for calling C<make quickcover> to perform coverage analysis,
+In preparation for calling C<make cover> to perform coverage analysis,
 provide a user-specified directory for top level of HTML output.
 
 =item Operating system-specific configuration options

--- a/config/gen/makefiles/root.in
+++ b/config/gen/makefiles/root.in
@@ -820,8 +820,8 @@ help :
 	@echo "  apilist:           Show list of PARROT_API functions"
 	@echo "  exportlist:        Show list of PARROT_EXPORT functions"
 	@echo "  malloclist:        Show list of PARROT_MALLOC functions"
-	@echo "  quickcover:        Run test suite coverage analysis (core)."
-	@echo "  cover:             Run test suite coverage analysis (full)."
+	@echo "  cover:             Run test suite coverage analysis (core)."
+	@echo "  fullcover:         Run test suite coverage analysis (full)."
 	@echo "  tags-vi:           Create tags for the vi editor."
 	@echo "  tags-emacs:        Create tags for the Emacs editor."
 	@echo "  perlcritic:        Check Perl code with Perl::Critic."
@@ -2148,7 +2148,7 @@ configure_tests :
 headerizer_tests : test_prep
 	$(PERL) t/harness $(HEADERIZER_TEST_FILES)
 
-# library tests - tests run by make test but not by make fulltest or make cover
+# library tests - tests run by make test but not by make fulltest or make fullcover
 library_tests : test_prep
 	$(PERL) t/harness $(EXTRA_TEST_ARGS) $(LIBRARY_TEST_FILES)
 
@@ -2597,7 +2597,7 @@ splint : all
 
 COVER_FLAGS = -fprofile-arcs -ftest-coverage
 
-COVER_DIRS = \
+FULLCOVER_DIRS = \
     src \
     src/call \
     src/dynoplibs \
@@ -2621,7 +2621,7 @@ COVER_DIRS = \
     $(BUILD_DIR)/t/perl \
     compilers/imcc
 
-cover: \
+fullcover: \
     cover.dummy \
     cover-testb \
     cover-testf \
@@ -2636,7 +2636,7 @@ cover: \
     cover-examples \
     cover-distro
 	build_dir=$$PWD; \
-    for dir in $(COVER_DIRS); \
+    for dir in $(FULLCOVER_DIRS); \
     do \
 	cd $$dir; \
 	gcov *.c; \
@@ -2645,7 +2645,7 @@ cover: \
     done
 	cover -ignore_re '^\/usr\/local\/bin'
 
-QUICKCOVER_DIRS = \
+COVER_DIRS = \
     src \
     src/call \
     src/dynoplibs \
@@ -2672,12 +2672,12 @@ COVER       = @cover@
 GCOV        = @gcov@
 GCOV2PERL   = @gcov2perl@
 
-quickcover: \
+cover: \
     cover.dummy \
     cover-test_runcore
 	build_dir=$$PWD; \
     $(COVER) -delete; \
-    for dir in $(QUICKCOVER_DIRS); \
+    for dir in $(COVER_DIRS); \
     do \
 	cd $$dir; \
 	$(GCOV) *.c; \

--- a/docs/dev/coverage.pod
+++ b/docs/dev/coverage.pod
@@ -46,10 +46,10 @@ type in C<make cover> and leave to make a sandwich and something to drink
 because it's probably going to take a I<long> time to run. If you run into
 trouble, C<make fulltest> may be of some assistance.
 
-=head1 Quickcover
+=head1 Cover
 
-If you have run C<make cover> before, you know how long it takes to execute
-that command. Recently a new tool C<make quickcover> has been added that is
+If you have run C<make fullcover> before, you know how long it takes to execute
+that command. Recently a new tool C<make cover> has been added that is
 much faster, but does not run tests in all runcores.
 
 =cut


### PR DESCRIPTION
This is work for the GCI task:  http://socghop.appspot.com/gci/task/show/google/gci2010/parrot_perl_foundations/t129315595846

This task is associated with this ticket: http://trac.parrot.org/parrot/ticket/1900

This completes the task, but I couldn't get proper coverage from the targets either before or after my work.

If this is a general problem, I can have a look at it.
