### PR TITLE
Increases Role coverage to 73.7

### DIFF
--- a/src/pmc/role.pmc
+++ b/src/pmc/role.pmc
@@ -557,7 +557,7 @@ Returns whether the class does the role with the given C<*rolename>.
 
 =item C<INTVAL does_pmc(PMC *role)>
 
-Returns whether the class does the givne C<*role>.
+Returns whether the class does the given C<*role>.
 
 =cut
 

--- a/t/pmc/role.t
+++ b/t/pmc/role.t
@@ -20,7 +20,7 @@ Tests the Role PMC.
 .sub main :main
     .include 'test_more.pir'
 
-    plan(6)
+    plan(10)
 
 
     $P0 = new ['Role']
@@ -51,6 +51,36 @@ Tests the Role PMC.
     $S0 = $P2
     $I0 = $S0 == 'Wob'
     ok($I0, 'Role namespace was set correctly')
+
+    $P3 = $P1.'inspect'()
+    $S0 = $P3['name']
+    is($S0, "Wob", "inspect hash name correct")
+
+    $S0 = $P1
+    is($S0, "Wob", "name through get_string correct")
+    
+    # Test init with attributes in the init hash.
+    $P1 = new ['FixedStringArray']
+    $P1 = 1
+    $P1[0] = "test_attr"
+    $P2 = new ['Hash']
+    $P2['name'] = 'Attr Test'
+    $P2['attributes'] = $P1
+
+    $P0 = new ['Role'], $P2
+    $P3 = $P0."inspect"('attributes')
+    $I0 = exists $P3['test_attr']
+    is($I0, 1, "Init with attributes")
+
+    # Test init with just a namespace
+    $P2 = new ['Hash']
+    $P2['namespace'] = 'Bob'
+    $P0 = new ['Role'], $P2
+    $S0 = $P0."inspect"('namespace')
+    is($S0, "Bob", "Init with just namespace")
+    
+    # Test mark()
+    sweep 1
 .end
 
 ## TODO add more tests as this is documented and implemented


### PR DESCRIPTION
Added a couple tests for Role.pmc, and found a little typo in Role.pmc. 

Tests include inspect(), get_string vtable, init with attributes, init with just namespace, and GC mark. From 48.6%, that's 25.1% increase.

GCI Task Link: http://www.google-melange.com/gci/task/show/google/gci2010/parrot_perl_foundations/t129361577692
