### PR TITLE
GCI Task - Fix all tests in zeroargs_subs_checking branch

### DIFF
--- a/t/compilers/imcc/reg/alloc.t
+++ b/t/compilers/imcc/reg/alloc.t
@@ -26,8 +26,8 @@ lab:
 ex:
 .end
 .sub alligator
-    get_params "0", $P0
-    invokecc $P0
+    .param pmc foo
+    invokecc foo
 .end
 CODE
 Hi

--- a/t/compilers/imcc/syn/pcc.t
+++ b/t/compilers/imcc/syn/pcc.t
@@ -511,8 +511,13 @@ OUT
 
 my $too_many_args = <<'CODE';
 .sub main :main
+    push_eh eh
     'foo'(_ARGS_)
+    goto no_eh
+eh:
+    pop_eh
     say "didn't segfault"
+no_eh:
 .end
 
 .sub foo

--- a/t/compilers/imcc/syn/subflags.t
+++ b/t/compilers/imcc/syn/subflags.t
@@ -121,10 +121,12 @@ test flags on PIR subs
 .end
 
 .sub 'xyz' :multi(Integer) :subid('above')
+    .param pmc lure
     .return('xyz above')
 .end
 
 .sub 'xyz' :multi(String) :subid('below')
+    .param pmc lure
     .return('xyz below')
 .end
 

--- a/t/compilers/imcc/syn/tail.t
+++ b/t/compilers/imcc/syn/tail.t
@@ -48,9 +48,8 @@ pir_output_is( <<'CODE', <<'OUT', "tail call optimization, final position" );
 .end
 
 .sub _funcall
-    .local pmc function
-    .local pmc argv
-    get_params "0,0x20", function, argv
+    .param pmc function
+    .param pmc argv :slurpy
     print "[doing _funcall]\n"
     $I33 = defined function
     if $I33 goto doit
@@ -64,9 +63,8 @@ doit:
 
 ## Return quotient and remainder as two integers.
 .sub _floor
-    .local pmc arg1
-    .local pmc arg2
-    get_params "0,0", arg1, arg2
+    .param pmc arg1
+    .param pmc arg2
     $P1 = new 'Integer'
     $P1 = arg1 / arg2
     ## truncate.
@@ -80,9 +78,8 @@ doit:
 
 ## Return the sum and the two arguments as three integers.
 .sub _fib_step
-    .local pmc arg1
-    .local pmc arg2
-    get_params "0,0", arg1, arg2
+    .param pmc arg1
+    .param pmc arg2
     $P1 = new 'Integer'
     $P1 = arg1 + arg2
     set_returns "0,0,0", $P1, arg1, arg2

--- a/t/oo/composition.t
+++ b/t/oo/composition.t
@@ -46,12 +46,14 @@ Tests role composition in the OO implementation.
     .return('Snake!')
 .end
 .sub fire
+    .param pmc self
     .return("You're FIRED!")
 .end
 .sub fire2
     .return('BURNINATION!')
 .end
 .sub give_payrise
+    .param pmc self
     .return('You all get a pay rise of 0.0005%.')
 .end
 

--- a/t/oo/objects.t
+++ b/t/oo/objects.t
@@ -263,11 +263,13 @@ Tests the object/class subsystem.
 .end
 
 .sub sayFoo31
+    .param pmc self
     ok( 1, 'called method added before creating obj' )
 .end
 
 .namespace ['Bar31']
 .sub sayBar31
+    .param pmc self
     ok( 1, 'called method added after created obj' )
 .end
 
@@ -1638,38 +1640,40 @@ end:
 
 # set(obj: Pvalue, Iattr_idx)
 .sub Foo54__set
-    get_params "0,0", $P5, $S4
+    .param pmc arg1
+    .param string arg2
     ok( 1, "in Foo54__set" )
     interpinfo $P2, .INTERPINFO_CURRENT_OBJECT
-    setattribute $P2, $S4, $P5
+    setattribute $P2, arg2, arg1
     set_returns ""
     returncc
 .end
 
 # Pattr = get(obj: Iattr_idx)
 .sub Foo54__get
-    get_params "0", $S4
+    .param string arg
     ok( 1, "in Foo54__get" )
     interpinfo $P2, .INTERPINFO_CURRENT_OBJECT
-    getattribute $P5, $P2, $S4
+    getattribute $P5, $P2, arg
     set_returns "0", $P5
     returncc
 .end
 
 .sub Bar54__set
-    get_params "0,0", $P5, $S4
+    .param pmc arg1
+    .param string arg2
     interpinfo $P2, .INTERPINFO_CURRENT_OBJECT
     ok( 1, "in Bar54__set" )
-    setattribute $P2, $S4, $P5
+    setattribute $P2, arg2, arg1
     set_returns ""
     returncc
 .end
 
 .sub Bar54__get
-    get_params "0", $S4
+    .param string arg
     ok( 1, "in Bar54__get" )
     interpinfo $P2, .INTERPINFO_CURRENT_OBJECT
-    getattribute $P5, $P2, $S4
+    getattribute $P5, $P2, arg
     set_returns "0", $P5
     returncc
 .end
@@ -1757,18 +1761,21 @@ end:
 
 # set(obj: Pvalue, SClass, Sattr)
 .sub set
-    get_params "0,0,0", $P5, $S4, $S5
+    .param pmc value
+    .param string classname
+    .param string attrname
     interpinfo $P2, .INTERPINFO_CURRENT_OBJECT
-    setattribute $P2, $S5, $P5
+    setattribute $P2, attrname, value
     set_returns ""
     returncc
 .end
 
 # Pattr = get(obj: SClass, Sattr)
 .sub get
-    get_params "0,0", $S4, $S5
+    .param string classname
+    .param string attrname
     interpinfo $P2, .INTERPINFO_CURRENT_OBJECT
-    getattribute $P5, $P2, $S5
+    getattribute $P5, $P2, attrname
     set_returns "0", $P5
     returncc
 .end

--- a/t/pmc/class.t
+++ b/t/pmc/class.t
@@ -398,6 +398,8 @@ t_class_meth:
     ok($I0, 'add_vtable_override() with invalid name fails')
 .end
 .sub 'new_add_role'
+    .param pmc lure1
+    .param pmc lure2
     ok(1, 'overridden vtable method called')
 .end
 
@@ -817,10 +819,12 @@ t_class_meth:
 .end
 
 .sub 'foo1'
+    .param pmc self
     .return(1)
 .end
 
 .sub 'foo2'
+    .param pmc self
     .return(2)
 .end
 

--- a/t/pmc/multidispatch.t
+++ b/t/pmc/multidispatch.t
@@ -1025,11 +1025,14 @@ pir_output_is( <<'CODE', <<'OUTPUT', "multisub w/o .HLL" );
 .end
 
 .sub 'foo' :multi(Integer)
+    .param pmc lure
     print "foo(Integer)\n"
     .return (0)
 .end
 
 .sub 'foo' :multi(ResizablePMCArray, _)
+    .param pmc lure1
+    .param pmc lure2
     print "foo(ResizablePMCArray,_)\n"
     .return (0)
 .end
@@ -1053,11 +1056,14 @@ pir_output_is( <<'CODE', <<'OUTPUT', "multisub w/ .HLL, rt #39161" );
 .end
 
 .sub 'foo' :multi(Integer)
+    .param pmc lure
     print "foo(Integer)\n"
     .return (0)
 .end
 
 .sub 'foo' :multi(ResizablePMCArray, _)
+    .param pmc lure1
+    .param pmc lure2
     print "foo(ResizablePMCArray,_)\n"
     .return (0)
 .end
@@ -1089,10 +1095,12 @@ pir_output_is( <<'CODE', <<'OUTPUT', "multisub w/ flatten" );
 .end
 
 .sub 'foo' :multi(Integer)
+    .param pmc lure
     print "foo(Integer)\n"
 .end
 
 .sub 'foo' :multi(String)
+    .param pmc lure
     print "foo(String)\n"
 .end
 CODE
@@ -1133,10 +1141,12 @@ pir_output_is( <<'CODE', <<'OUTPUT', "keyed class name and multi" );
 .end
 
 .sub 'foo' :multi( [ 'Some'; 'Class' ])
+    .param pmc lure
     print "Called multi for class\n"
 .end
 
 .sub 'foo' :multi(_)
+    .param pmc lure
     print "Called wrong multi\n"
 .end
 CODE
@@ -1328,9 +1338,11 @@ pir_output_is( <<'CODE', <<'OUTPUT', "multi-dispatch on PMCNULL" );
     foo($P0)
 .end
 .sub foo :multi(String)
+    .param pmc lure
     say "string"
 .end
 .sub foo :multi(_)
+    .param pmc lure
     say "any"
 .end
 CODE

--- a/t/pmc/namespace-subs.t
+++ b/t/pmc/namespace-subs.t
@@ -148,12 +148,15 @@ specified behavior for :method, :vtable, :nsentry, and :anon.
 
 .namespace ['MultiSubTest']
 .sub 'multisubtest' :multi(int)
+    .param pmc lure
    .return("called int variant")
 .end
 .sub 'multisubtest' :multi(string)
+    .param pmc lure
    .return("called string variant")
 .end
 .sub 'multisubtest' :anon :multi(num)
+    .param pmc lure
    .return("called num variant")
 .end
 

--- a/t/pmc/nci.t
+++ b/t/pmc/nci.t
@@ -1666,21 +1666,22 @@ ERROR:
 .end
 
 .sub _call_back
-  get_params "0,0", $P5, $P6
+  .param pmc arg1
+  .param pmc arg2
   print "in callback\n"
   print "user data: "
-  print $P5
+  print arg1
   print "\n"
 
-  # P6 is a UnManagedStruct PMC containing a pointer to an integer
+  # arg2 is a UnManagedStruct PMC containing a pointer to an integer
   new $P2, ['ResizablePMCArray']
   push $P2, .DATATYPE_INT
   push $P2, 0
   push $P2, 0
-  assign $P6, $P2
+  assign arg2, $P2
 
   # print referenced integer in libnci_test.so
-  $I17 = $P6[0]
+  $I17 = arg2[0]
   print "external data: "
   print $I17
   print "\n"

--- a/t/pmc/object-meths.t
+++ b/t/pmc/object-meths.t
@@ -747,6 +747,7 @@ pir_output_is( <<'CODE', <<'OUTPUT', "method cache invalidation" );
     print o
 .end
 .sub ok2
+    .param pmc self
     .return("ok 2\n")
 .end
 .namespace [ "Foo" ]
@@ -1070,6 +1071,7 @@ pir_output_is( <<'CODE', <<'OUTPUT', "overloading find_method vtable" );
 .end
 
 .sub foo
+  .param pmc lure
   print "foo was called\n"
 .end
 


### PR DESCRIPTION
This is my work for the task : http://www.google-melange.com/gci/task/show/google/gci2010/parrot_perl_foundations/t129413283999

I fixed all the tests except t/compilers/imcc/imcpasm/opt1.t and t/compilers/imcc/imcpasm/opt2.t as expected (because of the strange imcc optimizer dysfunction).
Please, check especially the changes at t/op/calling.t "pir uses no ops" test, I don't understand why the $I16 and $I17 was used instead $I0 ans $I1 for example, so I'm not 100% sure the new test does the expected goal...
