### PR TITLE
Kapace/embed test

### DIFF
--- a/src/embed/api.c
+++ b/src/embed/api.c
@@ -620,6 +620,8 @@ a true value if this call is successful and false value otherwise.
 =cut
 
 */
+/* Whiteknight told me that theres no way to test this for now, so it should be
+commented out, for now.
 
 PARROT_API
 Parrot_Int
@@ -650,7 +652,7 @@ Parrot_api_set_stdhandles(Parrot_PMC interp_pmc, Parrot_Int in,
     UNUSED(dummy);
 
     EMBED_API_CALLOUT(interp_pmc, interp)
-}
+}*/
 
 /*
 

--- a/t/src/embed.t
+++ b/t/src/embed.t
@@ -10,7 +10,7 @@ use File::Spec::Functions;
 
 plan skip_all => 'src/parrot_config.o does not exist' unless -e catfile(qw/src parrot_config.o/);
 
-plan tests => 15;
+plan tests => 16;
 
 =head1 NAME
 
@@ -1112,6 +1112,103 @@ Pir compiler returned no prog
 OUTPUT
 
 }
+
+
+#c_output_is(linedirective(__LINE__) . <<'CODE', <<'OUTPUT', 'Test set_std_handles');
+#
+##include <stdio.h>
+##include <stdlib.h>
+##include <string.h>
+##include "parrot/parrot.h"
+##include "parrot/api.h"
+##include "parrot/embed.h"
+##include "parrot/extend.h"
+#
+#static void fail(const char *msg);
+#static Parrot_String createstring(Parrot_Interp interp, const char * value);
+#
+#static void fail(const char *msg)
+#{
+#    fprintf(stderr, "failed: %s\n", msg);
+#    exit(EXIT_FAILURE);
+#}
+#
+#static Parrot_String createstring(Parrot_Interp interp, const char * value)
+#{
+#    return Parrot_new_string(interp, value, strlen(value), (const char*)NULL, 0);
+#}
+#
+#
+#int main(int argc, const char **argv)
+#{
+#
+#    char * c_outstr = NULL;
+#    Parrot_Init_Args *initargs = NULL;
+#    Parrot_PMC interpmc = NULL;
+#    Parrot_PMC p_str = NULL, p_keyedstr = NULL;
+#    Parrot_String s_teststr = NULL, s_outstr = NULL;
+#
+#    FILE * stdout = fopen("/tmp/stdout", "w");
+#    /*FILE * stdin  = fopen("/tmp/stdin", "r");
+#    FILE * stderr = fopen("/tmp/stdin", "w");*/
+#
+#    GET_INIT_STRUCT(initargs);
+#    Parrot_api_make_interpreter(NULL, 0, initargs, &interpmc);
+#
+#    Parrot_api_set_stdhandles(interpmc, stdout, PIO_INVALID_HANDLE, PIO_INVALID_HANDLE);
+#    /* Now run a simple PIR program that outputs some text, and make sure that it is
+#       writen to the file instead of stdout etc */
+#    puts("Done");
+#    return 0;
+#
+#}
+#CODE
+#OUTPUT
+
+c_output_is(linedirective(__LINE__) . <<'CODE', <<'OUTPUT', "get set compiler" );
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "parrot/api.h"
+#include "parrot/embed.h"
+
+void fail(const char *msg);
+
+void fail(const char *msg)
+{
+    fprintf(stderr, "failed: %s\n", msg);
+    exit(EXIT_FAILURE);
+}
+
+int main(int argc, const char **argv)
+{
+    char * c_outstr = NULL;
+    Parrot_Init_Args *initargs = NULL;
+    Parrot_PMC interpmc = NULL;
+    Parrot_PMC apmc = NULL;
+    Parrot_PMC bpmc = NULL;
+    Parrot_String s_teststr = NULL, s_outstr = NULL;
+    int a;
+
+    GET_INIT_STRUCT(initargs);
+    Parrot_api_make_interpreter(NULL, 0, initargs, &interpmc);
+
+    Parrot_api_string_import_ascii(interpmc, "PIR", &s_teststr);
+    Parrot_api_load_language(interpmc, s_teststr);
+
+    Parrot_api_get_compiler(interpmc, s_teststr, &apmc);
+    Parrot_api_set_compiler(interpmc, s_teststr, apmc);
+    Parrot_api_get_compiler(interpmc, s_teststr, &bpmc);
+
+    printf ("%s\n", apmc == bpmc ? "True" : "False!");
+    puts("Done");
+    return 0;
+}
+CODE
+True
+Done
+OUTPUT
 
 # Local Variables:
 #   mode: cperl


### PR DESCRIPTION
This increases embed api's coverage up to 78.2%. Tests include get/set compiler and set_std_handles.

According to whiteknight ( http://irclog.perlgeek.de/parrot/2010-12-29#i_3128033 ), the set_std_handle test and function should commented out for now, since there is no way to test.

GCI Task Link: http://www.google-melange.com/gci/task/show/google/gci2010/parrot_perl_foundations/t129336697097
