### PR TITLE
Fix Parrot library implementation of SHA256.

### DIFF
--- a/t/library/sha.t
+++ b/t/library/sha.t
@@ -36,39 +36,32 @@ regressions in the parrot VM, JIT and GC
 .sub test_basic
     $P0 = sha256sum("blah")
     $S0 = sha256_hex($P0)
-    $I0 = $S0 == "8b7df143d91c716ecfa5fc1730022f6b421b05cedee8fd52b1fc65a96030ad52"
-    todo($I0, "Basic SHA test", "See TT #1936")
+    is($S0, "8b7df143d91c716ecfa5fc1730022f6b421b05cedee8fd52b1fc65a96030ad52", "Basic SHA test")
 .end
 
 .sub test_miscellaneous_words
     $P0 = sha256sum ("Hello")
     $S0 = sha256_hex($P0)
-    #is($S0, '185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969', 'sha256 Hello')
-    $I0 = $S0 == '185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969'
-    todo($I0, "sha256 Hello", 'See TT #1936')
+    is($S0, '185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969', 'sha256 Hello')
 
     $P0 = sha256sum ("Goodbye")
     $S0 = sha256_hex($P0)
-    $I0 = $S0 == 'c015ad6ddaf8bb50689d2d7cbf1539dff6dd84473582a08ed1d15d841f4254f4'
-    todo($I0,'sha256 Goodbye', 'See TT #1936')
+    is($S0, 'c015ad6ddaf8bb50689d2d7cbf1539dff6dd84473582a08ed1d15d841f4254f4', 'sha256 Goodbye')
 
     $P0 = sha256sum ("Parrot")
     $S0 = sha256_hex($P0)
-    $I0 = $S0 == '21957106f22269fcf84cfd8bcd7b11c353b8155582ec8eae584dc876457787f8'
-    todo($I0, 'sha256 Parrot', 'See TT #1936')
+    is($S0, '21957106f22269fcf84cfd8bcd7b11c353b8155582ec8eae584dc876457787f8', 'sha256 Parrot')
 
     $P0 = sha256sum ("Hello World!")
     $S0 = sha256_hex($P0)
-    $I0 = $S0 == '7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069'
-    todo($I0, 'sha256 Hello World', 'See TT #1936')
+    is($S0, '7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069', 'sha256 Hello World')
 .end
 
 .sub test_object_interface
     $P0 = new ["Digest";"SHA256"]
     $P0."sha_sum"("Hello")
     $S0 = $P0."sha_hex"()
-    $I0 = $S0 == '185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969'
-    todo($I0, 'sha256 Hello via object interface', 'See TT #1936')
+    is($S0, '185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969', 'sha256 Hello via object interface')
 .end
 
 # Local Variables:


### PR DESCRIPTION
Reversed the optimization of the W[] byte array, it is now expanded once, linearly instead of circularly on-the-fly. (Uses 64 bytes instead of 16.)
