### PR TITLE
Increased test coverage for PackfileOpMap PMC

### DIFF
--- a/t/pmc/packfileopmap.t
+++ b/t/pmc/packfileopmap.t
@@ -80,6 +80,18 @@ Tests the PackfileOpMap PMC.
 
     $I0 = opmap
     is($I0, 4, "opmap correctly reports the number of mapped ops")
+
+    $P0 = opmap['say_sc']
+    $S0 = $P0
+    is($S0, 'say_sc', 'opmap returns the correct named op')
+
+    push_eh invalid_op_name
+    $P0 = opmap['speak_ne']
+    ok(0, 'opmap throws an exception on invalid op name')
+
+  invalid_op_name:
+    ok(1, 'caught invalid op name')
+    pop_eh
 .end
 
 .sub 'load_lib'


### PR DESCRIPTION
Increased from 48.1 to 77.9

Task: http://www.google-melange.com/gci/task/show/google/gci2010/parrot_perl_foundations/t129452277551#c1001
