### PR TITLE
Fix to build with MinGW-gcc-4.5.0

### DIFF
--- a/config/gen/platform/win32/begin.c
+++ b/config/gen/platform/win32/begin.c
@@ -2,14 +2,12 @@
  * Copyright (C) 2004-2010, Parrot Foundation.
  */
 
+#ifndef WINVER
+#  define WINVER 0x0500
+#endif
+
 #include <windows.h>
 
-#ifdef __MINGW32__
-#  include <w32api.h>
-#  if WINVER < Windows2000
-#    error Minimum requirement for Parrot on Windows is Windows 2000 - might want to check windef.h
-#  endif
-#endif
 
 /*
  * Local variables:

--- a/src/pmc/sub.pmc
+++ b/src/pmc/sub.pmc
@@ -484,7 +484,7 @@ Invokes the subroutine.
 
                 if (PMC_IS_NULL(outer_sub->ctx)) {
                     PMC * const dummy = Parrot_alloc_context(INTERP,
-                                                outer_sub->n_regs_used, NULL);
+                                                outer_sub->n_regs_used, PMCNULL);
                     Parrot_pcc_set_sub(INTERP, dummy, outer_pmc);
 
                     if (!PMC_IS_NULL(outer_sub->lex_info)) {


### PR DESCRIPTION
mingw-gcc:
http://sourceforge.net/projects/mingw/files/Automated MinGW Installer/mingw-get-inst/mingw-get-inst-20101030/

config:
perl Configure.pl --optimize

Without PMCNULL in src/pmc/sub.pmc parrot-nqp.exe don't work.
