### PR TITLE
Hackbinary/doc updates

### DIFF
--- a/docs/glossary.pod
+++ b/docs/glossary.pod
@@ -267,7 +267,7 @@ See also pddsE<47>pdd00_pdd.pod
 =begin html
 
 See also <a href="pdds/pdd00_pdd.pod.html">pdd00_pdd.pod.html</a>
-(Just <a href="https://github.com/parrot/parrot/blob/master/docs/pdds/pdd00_pdd.pod">pdd00_pdd.pod</a> on GitHub)<br />
+ (just <a href="https://github.com/parrot/parrot/blob/master/docs/pdds/pdd00_pdd.pod">pdd00_pdd.pod</a> on GitHub).<br />
 
 =end html
 
@@ -376,7 +376,7 @@ See also running.pod
 =begin html
 
 See also <a href="pdds/pdd00_pdd.pod.html">running.pod.html</a>
-(Just <a href="https://github.com/parrot/parrot/blob/master/docs/running.pod">running.pod</a> on Github.<br />
+(Just <a href="https://github.com/parrot/parrot/blob/master/docs/running.pod">running.pod</a> on Github).<br />
 
 =end html
 


### PR DESCRIPTION
Hello all,
- I have updated glossary.pod in /docs.
- I have added PIRC, PIRATE and PASM to the glossary.
- I have updated broken links, so they goto the appropriate place in GitHub.  I had to use absolute URL's because POD doesn't seem to like relative URLs
- I have fixed some spelling errors, defaulting to US/Canadian English.
