### PR TITLE
[docs] Fix runaway PIR_FRAGMENT regions.

### DIFF
--- a/docs/book/pir/ch03_basic_syntax.pod
+++ b/docs/book/pir/ch03_basic_syntax.pod
@@ -266,7 +266,7 @@ true or false before jumping:
 
   if $I0 > 5 goto GREET
 
-=end PIR_FRAGMENT
+=end PIR_FRAGMENT_INVALID
 
 You can construct any traditional control structure from PIR's built-in control structures.
 

--- a/docs/book/pir/ch04_variables.pod
+++ b/docs/book/pir/ch04_variables.pod
@@ -1314,7 +1314,7 @@ reached the end of the aggregate:
 
       if $P1 goto iter_repeat
 
-=end PIR_FRAGMENT
+=end PIR_FRAGMENT_INVALID
 
 Parrot provides predefined constants for working with iterators.
 C<.ITERATE_FROM_START> and C<.ITERATE_FROM_END> constants select whether an


### PR DESCRIPTION
fix mismatched =begin/=end sections that were causing some html mis-formattings in the PIR book.
