### PR TITLE
avoid NCI-related test failures.

### DIFF
--- a/t/library/nciutils.t
+++ b/t/library/nciutils.t
@@ -29,12 +29,14 @@ Testing Perl 6 objects.
     $P0 = getinterp
     $P1 = $P0[.IGLOBALS_CONFIG_HASH]
     $I1 = $P1['HAS_EXTRA_NCI_THUNKS']
-    if $I1 == 1 goto have_extra_nci_thunks
+    if $I1 == 1 goto have_enough_nci
+    $I1 = $P1['HAS_LIBFFI']
+    if $I1 == 1 goto have_enough_nci
 
     skip_all('No NCI thunks')
     exit 0
 
-  have_extra_nci_thunks:
+  have_enough_nci:
     ##  set our plan
     plan(13)
 

--- a/t/pmc/nci.t
+++ b/t/pmc/nci.t
@@ -32,8 +32,8 @@ Most tests are skipped when the F<libnci_test.so> shared library is not found.
 $ENV{TEST_PROG_ARGS} ||= '';
 
 SKIP: {
-    unless ($PConfig{HAS_EXTRA_NCI_THUNKS}) {
-        plan skip_all => "Parrot not built with extra NCI thunks";
+    unless ($PConfig{HAS_EXTRA_NCI_THUNKS} || $PConfig{HAS_LIBFFI}) {
+        plan skip_all => "Parrot built without libffi or extra NCI thunks";
     }
     unless ( -e "runtime/parrot/dynext/libnci_test$PConfig{load_ext}" ) {
         plan skip_all => "Please make libnci_test$PConfig{load_ext}";


### PR DESCRIPTION
only run these tests if Parrot was built with at least one of (extra_nci_thunks, libffi).  should fix some or all of TT#2116, TT#2117 and #1979.
