### PR TITLE
skip PCRE tests when neither FFI nor extra_nci_thunks are available.

### DIFF
--- a/t/library/pcre.t
+++ b/t/library/pcre.t
@@ -7,6 +7,7 @@ use lib qw( t . lib ../lib ../../lib );
 
 use Test::More;
 use Parrot::Test tests => 2;
+use Parrot::Config qw(%PConfig);
 
 =head1 NAME
 
@@ -43,6 +44,11 @@ if ($has_pcre && ($^O !~ /MSWin32/)) {
 SKIP: {
     skip( 'no pcre-config', Test::Builder->new()->expected_tests() )
         unless $has_pcre;
+
+    unless ($PConfig{HAS_EXTRA_NCI_THUNKS} || $PConfig{HAS_LIBFFI}) {
+        skip( 'Parrot built without libffi or extra NCI thunks',
+              Test::Builder->new()->expected_tests() );
+    }
 
 ## 1
 ## Check that the library can be loaded and initialized,


### PR DESCRIPTION
fixes failing PCRE tests, noted by jkeenan++ in comments to TT#2116.
