### PR TITLE
fix C++ build failure due to unexpected const-ness

### DIFF
--- a/src/string/api.c
+++ b/src/string/api.c
@@ -3050,7 +3050,7 @@ Parrot_str_join(PARROT_INTERP, ARGIN_NULLOK(STRING *j), ARGIN(PMC *ar))
         VTABLE_push_string(interp, sb, first);
 
         for (i = 1; i < count; ++i) {
-            const STRING *part = VTABLE_get_string_keyed_int(interp, ar, i);
+            STRING *part = VTABLE_get_string_keyed_int(interp, ar, i);
             if (j_length)
                 VTABLE_push_string(interp, sb, j);
 


### PR DESCRIPTION
VTABLE_push_string() expects a non-const STRING.  c++ says this is Not
Allowed.  This fixes it.
