### PR TITLE
[TT#2107] Fix dynloading of libraries from exact file name.

### DIFF
--- a/src/dynext.c
+++ b/src/dynext.c
@@ -346,7 +346,7 @@ get_path(PARROT_INTERP, ARGIN_NULLOK(STRING *lib), Parrot_dlopen_flags flags,
 
     /* And on cygwin replace a leading "lib" by "cyg". */
 #ifdef __CYGWIN__
-    if (!STRING_length(lib) >= 3 && memcmp(lib->strstart, "lib", 3) == 0) {
+    if (STRING_length(lib) >= 3 && memcmp(lib->strstart, "lib", 3) == 0) {
         path = Parrot_str_concat(interp, CONST_STRING(interp, "cyg"),
             STRING_substr(interp, lib, 3, lib->strlen - 3));
 
@@ -357,7 +357,7 @@ get_path(PARROT_INTERP, ARGIN_NULLOK(STRING *lib), Parrot_dlopen_flags flags,
     }
 #endif
 
-    if (!STRING_length(lib)) {
+    if (STRING_length(lib)) {
         *handle = dlopen_string(interp, flags, lib);
         if (*handle)
             return lib;


### PR DESCRIPTION
This should fix a problem introduced by 91161252e461284a causing loadlib to fail if its argument is a full file name including extension and all, and not located in the parrot runtime directory.

References:
http://trac.parrot.org/parrot/ticket/2107
https://bugs.gentoo.org/377379
https://bugs.gentoo.org/349297
https://github.com/parrot/parrot/commit/91161252e461284a1077#L1R350
