### PR TITLE
Isn't it cleaner (and also backwards compatible) to recommend:  

### DIFF
--- a/docs/project/git_workflow.pod
+++ b/docs/project/git_workflow.pod
@@ -70,7 +70,7 @@ get the latest commits with:
 
 Then use this syntax to track the remote branch with a local branch:
 
-  git checkout -b username/foo origin/username/foo
+  git checkout -t origin/username/foo
 
 If you are using a very old version of Git, such as 1.5.x.x or older, you will
 want to tell it to track the remote branch:


### PR DESCRIPTION
Isn't it cleaner (and also backwards compatible) to recommend:  
  git checkout -t origin/username/foo

Instead of what you have currently, which is:
  git checkout -b username/foo origin/username/foo
...

Sorry if I'm being ignorant, but the former was recommended to me in irc.freenode.net/#git so I thought I'd pass it along.
