### PR TITLE
Add a Parrot_api_pmc_box_float function to src/embed/pmc.c

### DIFF
--- a/include/parrot/api.h
+++ b/include/parrot/api.h
@@ -485,6 +485,14 @@ Parrot_Int Parrot_api_string_import_wchar(
 /* Don't modify between HEADERIZER BEGIN / HEADERIZER END.  Your changes will be lost. */
 
 PARROT_API
+Parrot_Int Parrot_api_pmc_box_float(
+    Parrot_PMC interp_pmc,
+    Parrot_Float value,
+    ARGOUT(Parrot_PMC * float_pmc))
+        __attribute__nonnull__(3)
+        FUNC_MODIFIES(* float_pmc);
+
+PARROT_API
 Parrot_Int Parrot_api_pmc_box_integer(
     Parrot_PMC interp_pmc,
     Parrot_Int value,
@@ -716,6 +724,8 @@ Parrot_Int Parrot_api_pmc_wrap_string_array(
         __attribute__nonnull__(4)
         FUNC_MODIFIES(* args);
 
+#define ASSERT_ARGS_Parrot_api_pmc_box_float __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
+       PARROT_ASSERT_ARG(float_pmc))
 #define ASSERT_ARGS_Parrot_api_pmc_box_integer __attribute__unused__ int _ASSERT_ARGS_CHECK = (\
        PARROT_ASSERT_ARG(int_pmc))
 #define ASSERT_ARGS_Parrot_api_pmc_box_string __attribute__unused__ int _ASSERT_ARGS_CHECK = (\

--- a/src/embed/pmc.c
+++ b/src/embed/pmc.c
@@ -433,7 +433,7 @@ Parrot_api_pmc_box_string(ARGIN(Parrot_PMC interp_pmc), ARGIN(Parrot_String str)
 =item C<Parrot_Int Parrot_api_pmc_box_integer(Parrot_PMC interp_pmc, Parrot_Int
 value, Parrot_PMC * int_pmc)>
 
-Wraps the integer C<str> into a PMC and stores the results in C<int_pmc>. This
+Wraps the integer C<value> into a PMC and stores the results in C<int_pmc>. This
 function returns a true value if this call is successful and false value
 otherwise.
 
@@ -448,12 +448,33 @@ Parrot_api_pmc_box_integer(Parrot_PMC interp_pmc, Parrot_Int value,
 {
     ASSERT_ARGS(Parrot_api_pmc_box_integer)
     EMBED_API_CALLIN(interp_pmc, interp)
-    *int_pmc = Parrot_pmc_new(interp, enum_class_Integer);
-    VTABLE_set_integer_native(interp, *int_pmc, value);
+    *int_pmc = Parrot_pmc_box_integer(interp, value);
     EMBED_API_CALLOUT(interp_pmc, interp)
 }
 
-/* TODO: Box float */
+/*
+
+=item C<Parrot_Int Parrot_api_pmc_box_float(Parrot_PMC interp_pmc, Parrot_Float
+value, Parrot_PMC * float_pmc)>
+
+Wraps the float C<value> into a PMC and stores the results in C<float_pmc>. This
+function returns a true value if this call is successful and false value
+otherwise.
+
+=cut
+
+*/
+
+PARROT_API
+Parrot_Int
+Parrot_api_pmc_box_float(Parrot_PMC interp_pmc, Parrot_Float value,
+        ARGOUT(Parrot_PMC * float_pmc))
+{
+    ASSERT_ARGS(Parrot_api_pmc_box_float)
+    EMBED_API_CALLIN(interp_pmc, interp)
+    *float_pmc = Parrot_pmc_box_number(interp, value);
+    EMBED_API_CALLOUT(interp_pmc, interp)
+}
 
 /*
 

--- a/t/src/embed/pmc.t
+++ b/t/src/embed/pmc.t
@@ -24,7 +24,7 @@ Tests PMC API support.
 
 =cut
 
-plan tests => 7;
+plan tests => 8;
 
 c_output_is( <<'CODE', <<'OUTPUT', "get/set_keyed_int" );
 
@@ -342,6 +342,47 @@ int main(int argc, char* argv[])
 CODE
 Frozen and thawed: I am a string.
 I am a string.
+OUTPUT
+
+c_output_is( <<'CODE', <<'OUTPUT', "Test pmc_box and pmc_get" );
+
+#include <parrot/api.h>
+#include <stdio.h>
+
+int main(int argc, char* argv[])
+{
+    Parrot_Init_Args *initargs = NULL;
+    Parrot_PMC interpmc = NULL;
+    Parrot_PMC p_str = NULL, p_float = NULL, p_int = NULL;
+    Parrot_String s_teststr = NULL, s_outstr = NULL;
+    Parrot_Float outfloat = 0.0;
+    Parrot_Int outint = 0;
+    char *c_outstr = NULL;
+    int answer = 0;
+
+    GET_INIT_STRUCT(initargs);
+    Parrot_api_make_interpreter(NULL, 0, initargs, &interpmc);
+
+    Parrot_api_string_import_ascii(interpmc, "The answer is", &s_teststr);
+    Parrot_api_pmc_box_string(interpmc, s_teststr, &p_str);
+    Parrot_api_pmc_get_string(interpmc, p_str, &s_outstr);
+    Parrot_api_string_export_ascii(interpmc, s_outstr, &c_outstr);
+    printf("%s ", c_outstr);
+
+    Parrot_api_pmc_box_float(interpmc, 10.5, &p_float);
+    Parrot_api_pmc_get_float(interpmc, p_float, &outfloat);
+
+    Parrot_api_pmc_box_integer(interpmc, 21, &p_int);
+    Parrot_api_pmc_get_integer(interpmc, p_int, &outint);
+
+    answer = (int)(2 * outfloat) + (int)outint;
+    printf("%i.\n", answer);
+
+    return 0;
+}
+
+CODE
+The answer is 42.
 OUTPUT
 
 # Local Variables:


### PR DESCRIPTION
Add a Parrot_api_pmc_box_float function to src/embed/pmc.c, change Parrot_api_pmc_box_integer to use Parrot_pmc_box_integer instead of duplicating it.
Also add a test for these functions to t/src/embed/pmc.t.

Smolder report: http://smolder.parrot.org/app/projects/report_details/24630
