### PR TITLE
Don't silently ignore missing hints files if one was explicitly requested

### DIFF
--- a/config/init/hints.pm
+++ b/config/init/hints.pm
@@ -63,6 +63,9 @@ sub runstep {
             $hints_used++;
         }
     }
+    elsif ( $conf->options->get('hintsfile') ) {
+        die "No $hints_file found";
+    }
     else {
         $conf->debug("No $hints_file found.  ");
     }


### PR DESCRIPTION
`init::hints` now dies if `--hintsfile` is present, but the file can't be found
