### PR TITLE
The '"' quote prevents it from compiling

### DIFF
--- a/examples/languages/squaak/doc/tutorial_episode_4.pod
+++ b/examples/languages/squaak/doc/tutorial_episode_4.pod
@@ -306,7 +306,7 @@ action methods.
      ## generate instruction to retrieve the exception object (and the
      ## exception message, that is passed automatically in PIR, this is stored
      ## into $S0 (but not used).
-     my $pir := "    .get_results (%r, $S0)\n"
+     my $pir := '    .get_results (%r, $S0)\n'
               ~ "    store_lex '" ~ $exc.name()
               ~ "', %r";
 


### PR DESCRIPTION
I have been going through the tutorial and until I changed the quote character it would not compile.  I received the error.

Symbol '$S0' not predeclared in statement:sym<try>

After changing it everything works.
