### PR TITLE
The size of the M0_META_SEG should include the header

### DIFF
--- a/src/m0/perl5/m0_assembler.pl
+++ b/src/m0/perl5/m0_assembler.pl
@@ -223,7 +223,7 @@ sub m0b_metadata_seg {
 
     my $bytecode  = pack("i", $M0_META_SEG);
     $bytecode    .= pack("i", $entry_count);
-    $bytecode    .= pack("i", $entry_count * 12);
+    $bytecode    .= pack("i", $entry_count * 12 + 12);
 
     #for each entry
     for (split /\n/, $metadata) {


### PR DESCRIPTION
The size of the M0_META_SEG should include the size of the meta segment header per the spec, but it is not included in the C implementation.
