### PR TITLE
mark stack-overflow gc for clang -faddress-sanitizer

### DIFF
--- a/src/gc/system.c
+++ b/src/gc/system.c
@@ -435,6 +435,9 @@ areas.
 
 */
 
+#if defined(__clang__) && defined(__has_feature) && __has_feature(address_sanitizer)
+__attribute__((no_address_safety_analysis))
+#endif
 static void
 trace_mem_block(PARROT_INTERP,
         ARGIN_NULLOK(const Memory_Pools *mem_pools),


### PR DESCRIPTION
http://clang.llvm.org/docs/AddressSanitizer.html fails in
trace_mem_block() with a stack invalid READ, which is actually valid in our GC.
Since this is the only function we just use the recommended detection and attribute
here once.

Personally I'm not quite convinced that parrot's GC really does that. But with this 
attribute all tests pass now.
