### PR TITLE
Mark --leak-test to be skipped with AddressSanitizer

### DIFF
--- a/src/exit.c
+++ b/src/exit.c
@@ -111,6 +111,7 @@ the interpreter is destroyed.
 */
 
 PARROT_COLD
+PARROT_NO_ADDRESS_SAFETY_ANALYSIS
 void
 Parrot_x_execute_on_exit_handlers(PARROT_INTERP, int status)
 {
@@ -134,6 +135,7 @@ Parrot_x_execute_on_exit_handlers(PARROT_INTERP, int status)
         node = next;
     }
 
+    /* It could be that the interpreter already is destroyed. See issue 765 */
     interp->exit_handler_list = NULL;
 
     /* Re-enable GC, which we will want if GC finalizes */

--- a/t/run/options.t
+++ b/t/run/options.t
@@ -116,7 +116,7 @@ like( $output, qr/maximum GC nursery size is 50%/,
 is( $exit, 0, '... and should not crash' );
 
 
-# Test --leak-test
+# Test --leak-test. See issue GH #765
 is( qx{$PARROT --leak-test "$first_pir_file"}, "first\n", '--leak-test' );
 
 # clean up temporary files


### PR DESCRIPTION
See issue GH #765. interp can be already freed, but avoid checking it for now.
