### PR TITLE
M0 c use ops list

### DIFF
--- a/src/m0/c/m0.h
+++ b/src/m0/c/m0.h
@@ -17,6 +17,7 @@ enum {
 };
 
 enum M0_OPS {
+    /* gen_c_opnames_from(m0.ops) template('    M0_UC_OP,') */
     M0_NOOP,
     M0_GOTO,
     M0_GOTO_IF,
@@ -35,8 +36,8 @@ enum M0_OPS {
     M0_ISGT_N,
     M0_ISGE_I,
     M0_ISGE_N,
-    M0_ITON,
-    M0_NTOI,
+    M0_CONVERT_I_N,
+    M0_CONVERT_N_I,
     M0_ASHR,
     M0_LSHR,
     M0_SHL,
@@ -63,6 +64,7 @@ enum M0_OPS {
     M0_PRINT_I,
     M0_PRINT_N,
     M0_EXIT
+    /* end_gen */
 };
 
 typedef uint64_t M0_Config[8];

--- a/src/m0/c/ops.c
+++ b/src/m0/c/ops.c
@@ -518,11 +518,11 @@ run_ops( M0_Interp *interp, M0_CallFrame *cf ) {
                     M0_EXEC_OP(get_word, cf, ops, pc);
                 break;
 
-                case (M0_ITON):
+                case (M0_CONVERT_I_N):
                     M0_EXEC_OP(convert_i_n, cf, ops, pc);
                 break;
 
-                case (M0_NTOI):
+                case (M0_CONVERT_N_I):
                     M0_EXEC_OP(convert_n_i, cf, ops, pc);
                 break;
 

--- a/tools/dev/m0_opcheck.pl
+++ b/tools/dev/m0_opcheck.pl
@@ -16,6 +16,7 @@ use File::Slurp;
 my @m0_files = qw<
 src/m0/perl5/m0_assembler.pl
 src/m0/perl5/m0_interp.pl
+src/m0/c/m0.h
 >;
 
 
@@ -36,6 +37,21 @@ foreach my $file (@m0_files) {
                 $op_name =~ s/LC_OP/$op/;
                 push @fixed_lines, "$op_name\n";
             }
+        }
+        elsif ($line =~ /gen_c_opnames_from\(m0\.ops\)/) {
+            push @fixed_lines, $line;
+            my $template = $line;
+            $template =~ s/.*template\('([^']*)'\).*\*\/.*\n/$1/;
+            $op_gen = 'names';
+            foreach my $op (m0_ops()) {
+                my $op_name = $template;
+                my $uc_op = uc($op);
+                $op_name =~ s/UC_OP/$uc_op/;
+                push @fixed_lines, "$op_name\n";
+            }
+            my $last_line = pop @fixed_lines;
+            $last_line =~ s/,\s*$/\n/;
+            push @fixed_lines, $last_line
         }
         elsif ($op_gen) {
             if ($line =~ /end_gen/) {


### PR DESCRIPTION
Add a way to generate ops lists for C files, add m0.h to
the list of files to process and add templates to m0.h.

Also, change M0_ITON and M0_NTOI to M0_CONVERT_I_N and
M0_CONVERT_N_I respectively.
