### PR TITLE
Update runtime/parrot/library/MIME/Base64.pir

### DIFF
--- a/runtime/parrot/library/MIME/Base64.pir
+++ b/runtime/parrot/library/MIME/Base64.pir
@@ -1,4 +1,3 @@
-
 =head1 NAME
 
 MIME::Base64 -  Encoding and decoding of base64 strings
@@ -189,7 +188,7 @@ Characters occurring after a '=' padding character are never decoded.
     .local int    enc_num
     base64_cleaned = ''
     if has_enc goto HAS_ENC
-      enc = 'ascii'
+      enc = 'utf8'
   HAS_ENC:
 
     .local pmc eight_to_six, bb


### PR DESCRIPTION
utf8 just seems to make more sense as a string decoding default than ascii and it doesn't seem to break any tests.  Of course the base64 string is in ascii but utf8 seems to be a more reasonable default case for the decoded result string.
