### PR TITLE
Fix returning NULL from CallContext->get_attr

### DIFF
--- a/src/pmc/callcontext.pmc
+++ b/src/pmc/callcontext.pmc
@@ -1019,8 +1019,9 @@ return current Namespace
         else
             Parrot_ex_throw_from_c_args(INTERP, NULL,
                 EXCEPTION_ATTRIB_NOT_FOUND, "No such attribute '%S'", key);
-
-        return value;
+	if(value)
+	    return value;
+	return PMCNULL;
     }
 
     VTABLE INTVAL elements() {


### PR DESCRIPTION
This commit checks for NULL in CallContext->get_attr,
and replaces it with PMCNULL. This fixes a crash in NQP, 
which stopped me from building.

[Coke] has suggested to put this check into the (macro of) GET_ATTR,
which would save us the need to check for it everywhere, but we would
have to know it the retrieved attribute is a PMC or string or otherwise.
