### PR TITLE
Change some dependency rules to make them work with VMS.

### DIFF
--- a/config/auto/pmc.pm
+++ b/config/auto/pmc.pm
@@ -125,13 +125,11 @@ END
 
         my $o_deps = "    " . join(" \\\n    ", keys %o_deps);
         $TEMP_pmc_build .= <<END
-src/pmc/$pmc.c : src/pmc/$pmc.dump
+include/pmc/pmc_$pmc.h src/pmc/$pmc.c : src/pmc/$pmc.dump
 \t\$(PMC2CC) src/pmc/$pmc.pmc
 
 src/pmc/$pmc.dump : vtable.dump $parent_dumps src/pmc/$pmc.pmc \$(PMC2C_FILES) $pccmethod_depend
 \t\$(PMC2CD) src/pmc/$pmc.pmc
-
-include/pmc/pmc_$pmc.h: src/pmc/$pmc.c
 
 ## SUFFIX OVERRIDE -Warnings
 src/pmc/$pmc\$(O): \\

--- a/src/dynpmc/Rules.in
+++ b/src/dynpmc/Rules.in
@@ -7,13 +7,12 @@ $(DYNEXT_DIR)/dynlexpad$(LOAD_EXT): src/dynpmc/dynlexpad$(O)
 #IF(win32):	if exist $@.manifest mt.exe -nologo -manifest $@.manifest -outputresource:$@;2
 #IF(cygwin or hpux):   $(CHMOD) 0775 $@
 
-src/dynpmc/pmc_dynlexpad.h : src/dynpmc/dynlexpad.c
-
 src/dynpmc/dynlexpad$(O): \
     src/dynpmc/dynlexpad.c \
     $(DYNPMC_H_FILES) \
     src/dynpmc/pmc_dynlexpad.h
 
+src/dynpmc/pmc_dynlexpad.h \
 src/dynpmc/dynlexpad.c: src/dynpmc/dynlexpad.dump
 	$(PMC2CC) src/dynpmc/dynlexpad.pmc
 
@@ -29,14 +28,13 @@ $(DYNEXT_DIR)/file$(LOAD_EXT): src/dynpmc/file$(O)
 #IF(win32):	if exist $@.manifest mt.exe -nologo -manifest $@.manifest -outputresource:$@;2
 #IF(cygwin or hpux):   $(CHMOD) 0775 $@
 
-src/dynpmc/pmc_file.h : src/dynpmc/file.c
-
 src/dynpmc/file$(O): \
     src/dynpmc/file.c \
     $(DYNPMC_H_FILES) \
     src/dynpmc/pmc_file.h \
     include/pmc/pmc_fixedintegerarray.h
 
+src/dynpmc/pmc_file.h \
 src/dynpmc/file.c: src/dynpmc/file.dump
 	$(PMC2CC) src/dynpmc/file.pmc
 
@@ -63,8 +61,6 @@ src/dynpmc/foo_group.c: $(DYNPMC_FOO_OBJS)
 	$(MV) foo_group.c src/dynpmc/foo_group.c
 	$(MV) foo_group.h src/dynpmc/foo_group.h
 
-src/dynpmc/pmc_foo.h : src/dynpmc/foo.c
-
 src/dynpmc/foo$(O): \
     src/dynpmc/foo.c \
     $(DYNPMC_H_FILES) \
@@ -72,13 +68,12 @@ src/dynpmc/foo$(O): \
     include/pmc/pmc_integer.h \
     include/pmc/pmc_scalar.h
 
+src/dynpmc/pmc_foo.h \
 src/dynpmc/foo.c: src/dynpmc/foo.dump
 	$(PMC2CC) src/dynpmc/foo.pmc
 
 src/dynpmc/foo.dump: src/dynpmc/foo.pmc vtable.dump $(CLASS_O_FILES)
 	$(PMC2CD) src/dynpmc/foo.pmc
-
-src/dynpmc/pmc_foo2.h : src/dynpmc/foo2.c
 
 src/dynpmc/foo2$(O): \
     src/dynpmc/foo2.c \
@@ -88,6 +83,7 @@ src/dynpmc/foo2$(O): \
     include/pmc/pmc_scalar.h \
     src/dynpmc/pmc_foo.h
 
+src/dynpmc/pmc_foo2.h \
 src/dynpmc/foo2.c: src/dynpmc/foo2.dump src/dynpmc/foo.pmc
 	$(PMC2CC) src/dynpmc/foo2.pmc
 
@@ -103,8 +99,6 @@ $(DYNEXT_DIR)/gziphandle$(LOAD_EXT): src/dynpmc/gziphandle$(O)
 #IF(win32):	if exist $@.manifest mt.exe -nologo -manifest $@.manifest -outputresource:$@;2
 #IF(cygwin or hpux):   $(CHMOD) 0775 $@
 
-src/dynpmc/pmc_gziphandle.h : src/dynpmc/gziphandle.c
-
 src/dynpmc/gziphandle$(O): \
     src/dynpmc/gziphandle.c \
     $(DYNPMC_H_FILES) \
@@ -112,6 +106,7 @@ src/dynpmc/gziphandle$(O): \
     include/pmc/pmc_handle.h \
     include/pmc/pmc_fixedintegerarray.h
 
+src/dynpmc/pmc_gziphandle.h \
 src/dynpmc/gziphandle.c: src/dynpmc/gziphandle.dump
 	$(PMC2CC) src/dynpmc/gziphandle.pmc
 
@@ -127,14 +122,13 @@ $(DYNEXT_DIR)/os$(LOAD_EXT): src/dynpmc/osdummy$(O)
 #IF(win32):	if exist $@.manifest mt.exe -nologo -manifest $@.manifest -outputresource:$@;2
 #IF(cygwin or hpux):   $(CHMOD) 0775 $@
 
-src/dynpmc/pmc_osdummy.h : src/dynpmc/osdummy.c
-
 src/dynpmc/osdummy$(O): \
     src/dynpmc/osdummy.c \
     $(DYNPMC_H_FILES) \
     src/dynpmc/pmc_osdummy.h \
     include/pmc/pmc_fixedintegerarray.h
 
+src/dynpmc/pmc_osdummy.h \
 src/dynpmc/osdummy.c: src/dynpmc/osdummy.dump
 	$(PMC2CC) src/dynpmc/osdummy.pmc
 
@@ -147,14 +141,13 @@ $(DYNEXT_DIR)/pccmethod_test$(LOAD_EXT): src/dynpmc/pccmethod_test$(O)
 		src/dynpmc/pccmethod_test$(O) $(LINKARGS)
 #IF(win32):	if exist $@.manifest mt.exe -nologo -manifest $@.manifest -outputresource:$@;2
 
-src/dynpmc/pmc_pccmethod_test.h : src/dynpmc/pccmethod_test.c
-
 src/dynpmc/pccmethod_test$(O): \
     src/dynpmc/pccmethod_test.c \
     $(DYNPMC_H_FILES) \
     src/dynpmc/pmc_pccmethod_test.h \
     include/pmc/pmc_fixedintegerarray.h
 
+src/dynpmc/pmc_pccmethod_test.h \
 src/dynpmc/pccmethod_test.c: src/dynpmc/pccmethod_test.dump
 	$(PMC2CC) src/dynpmc/pccmethod_test.pmc
 
@@ -170,8 +163,6 @@ $(DYNEXT_DIR)/rotest$(LOAD_EXT): src/dynpmc/rotest$(O)
 #IF(win32):	if exist $@.manifest mt.exe -nologo -manifest $@.manifest -outputresource:$@;2
 #IF(cygwin or hpux):   $(CHMOD) 0775 $@
 
-src/dynpmc/pmc_rotest.h : src/dynpmc/rotest.c
-
 src/dynpmc/rotest$(O): \
     src/dynpmc/rotest.c \
     $(DYNPMC_H_FILES) \
@@ -180,6 +171,7 @@ src/dynpmc/rotest$(O): \
     include/pmc/pmc_integer.h \
     include/pmc/pmc_scalar.h
 
+src/dynpmc/pmc_rotest.h \
 src/dynpmc/rotest.c: src/dynpmc/rotest.dump
 	$(PMC2CC) src/dynpmc/rotest.pmc
 
@@ -195,14 +187,13 @@ $(DYNEXT_DIR)/rational$(LOAD_EXT): src/dynpmc/rational$(O)
 #IF(win32):	if exist $@.manifest mt.exe -nologo -manifest $@.manifest -outputresource:$@;2
 #IF(cygwin or hpux):   $(CHMOD) 0775 $@
 
-src/dynpmc/pmc_rational.h : src/dynpmc/rational.c
-
 src/dynpmc/rational$(O): \
     src/dynpmc/rational.c \
     $(DYNPMC_H_FILES) \
     src/dynpmc/pmc_rational.h \
     include/pmc/pmc_fixedintegerarray.h
 
+src/dynpmc/pmc_rational.h \
 src/dynpmc/rational.c: src/dynpmc/rational.dump
 	$(PMC2CC) src/dynpmc/rational.pmc
 
@@ -218,14 +209,13 @@ $(DYNEXT_DIR)/subproxy$(LOAD_EXT): src/dynpmc/subproxy$(O)
 #IF(win32):	if exist $@.manifest mt.exe -nologo -manifest $@.manifest -outputresource:$@;2
 #IF(cygwin or hpux):   $(CHMOD) 0775 $@
 
-src/dynpmc/pmc_subproxy.h : src/dynpmc/subproxy.c
-
 src/dynpmc/subproxy$(O): \
     src/dynpmc/subproxy.c \
     $(DYNPMC_H_FILES) \
     src/dynpmc/pmc_subproxy.h \
     include/pmc/pmc_sub.h
 
+src/dynpmc/pmc_subproxy.h \
 src/dynpmc/subproxy.c: src/dynpmc/subproxy.dump
 	$(PMC2CC) src/dynpmc/subproxy.pmc
 
@@ -240,14 +230,13 @@ $(DYNEXT_DIR)/select$(LOAD_EXT): src/dynpmc/select$(O)
 #IF(win32):	if exist $@.manifest mt.exe -nologo -manifest $@.manifest -outputresource:$@;2
 #IF(cygwin or hpux):   $(CHMOD) 0775 $@
 
-src/dynpmc/pmc_select.h : src/dynpmc/select.c
-
 src/dynpmc/select$(O): \
     src/dynpmc/select.c \
     $(DYNPMC_H_FILES) \
     src/dynpmc/pmc_select.h \
     include/pmc/pmc_sub.h
 
+src/dynpmc/pmc_select.h \
 src/dynpmc/select.c: src/dynpmc/select.dump
 	$(PMC2CC) src/dynpmc/select.pmc
 


### PR DESCRIPTION
The VMS make utilities always need an action if they determine that a target is
older than a denpendency element.

Besides, rules like

some/header.h : some/source.c

some/source.c : some/file.dump
    $(PMC2CC) some/source.pmc

don't reflect the building process, as both the C and header file are generated
by the $(PMC2CC) call.
