### PR TITLE
Correct split match argument (codingstd)

### DIFF
--- a/config/auto/arch.pm
+++ b/config/auto/arch.pm
@@ -114,9 +114,9 @@ sub runstep {
         if ( $^O eq 'linux' ) {
             my $cpu_info;
             chomp( $cpu_info = qx{ cat /proc/cpuinfo } );
-            my @cpu_info_lines = split '\n', $cpu_info;
+            my @cpu_info_lines = split /\n/, $cpu_info;
             my $model_name_line = (grep m/model name/, @cpu_info_lines)[0];
-            my $model_name = (split ':', $model_name_line)[1];
+            my $model_name = (split /:/, $model_name_line)[1];
             $model_name =~ s/^\s+//;
             $cpu_type = $model_name;
         }


### PR DESCRIPTION
I should have run 'make codingstd_tests' before submitting the last change....
