### PR TITLE
Always use >  not  `perldoc -d`

### DIFF
--- a/config/auto/perldoc.pm
+++ b/config/auto/perldoc.pm
@@ -38,7 +38,7 @@ sub runstep {
 
     my $cmd = File::Spec->catfile($conf->data->get('scriptdirexp_provisional'), q{perldoc});
     my ( $fh, $filename ) = tempfile( UNLINK => 1 );
-    my $content = capture_output("$cmd -ud $filename perldoc") || undef;
+    my $content = capture_output("$cmd -u perldoc > $filename") || undef;
 
     return 1 unless defined( $self->_initial_content_check($conf, $content) );
 
@@ -67,7 +67,7 @@ E_NOTE
         if ( $new_perldoc ) {
             $TEMP_pod_build .= <<"END";
 ops/$pod: ../src/ops/$ops
-\t\$(PERLDOC) -ud ops/$pod ../src/ops/$ops
+\t\$(PERLDOC) -u ../src/ops/$ops > ops/$pod
 \t\$(CHMOD) 0644 ops/$pod
 \t\$(ADDGENERATED) "docs/\$\@" "[doc]"
 

--- a/config/gen/makefiles/docs.in
+++ b/config/gen/makefiles/docs.in
@@ -63,8 +63,7 @@ doc-prep:
 	$(TOUCH) doc-prep
 
 packfile-c.pod: ../src/packfile/api.c
-#IF(new_perldoc):	$(PERLDOC) -ud packfile-c.pod ../src/packfile/api.c
-#ELSE:	$(PERLDOC) -u ../src/packfile/api.c > packfile-c.pod
+	$(PERLDOC) -u ../src/packfile/api.c > packfile-c.pod
 	$(ADDGENERATED) "docs/$@" "[doc]"
 
 .pod.1 : # suffix rule (limited support)


### PR DESCRIPTION
perldoc -d $path is limited because perldoc SETUID's to `UID=nobody` if
`UID=0`, which basically guarantees that `perldoc -d $path` will not be
able to write anywhere in the working directory.

Though using redirection may be limited on some platforms, any competing
solution should change the code executed depending on platform.

On UNIX as UID=0, -d should **always** be avoided because of perldocs
inherent defects.
