### PR TITLE
Fix issue 976 (pcre library load on gentoo x64 system)

### DIFF
--- a/runtime/parrot/library/pcre.pir
+++ b/runtime/parrot/library/pcre.pir
@@ -78,6 +78,12 @@ LIB_DEFAULT:
     loaded = defined libpcre
     if loaded goto LIB_LOADED
 
+    # gentoo again issue: 976
+    loadlib libpcre, 'libpcre.so.1'
+    loaded = defined libpcre
+    if loaded goto LIB_LOADED
+
+
     branch LIB_FAILED
 
 LIB_WIN32:


### PR DESCRIPTION
Fix for the issue: https://github.com/parrot/parrot/issues/976
