### PR TITLE
Don't complain about utf8 multibyte characters split by chunk boundaries

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2013-09-17    release 5.8.0
     - Core
+        + Don't complain about utf8 multibyte characters split by chunk boundaries
     - Build
     - Documentation
     - Tests

--- a/src/string/encoding/utf8.c
+++ b/src/string/encoding/utf8.c
@@ -211,14 +211,15 @@ utf8_scan(PARROT_INTERP, ARGMOD(STRING *src))
 {
     ASSERT_ARGS(utf8_scan)
     Parrot_String_Bounds bounds;
+    INTVAL res;
 
     bounds.bytes = src->bufused;
     bounds.chars = -1;
     bounds.delim = -1;
 
-    utf8_partial_scan(interp, src->strstart, &bounds);
+    res = utf8_partial_scan(interp, src->strstart, &bounds);
 
-    if (bounds.bytes != src->bufused)
+    if (res == 0 && bounds.bytes != src->bufused)
         Parrot_ex_throw_from_c_args(interp, NULL, EXCEPTION_MALFORMED_UTF8,
             "Unaligned end in UTF-8 string\n");
 
@@ -261,6 +262,7 @@ utf8_partial_scan(PARROT_INTERP, ARGIN(const char *buf),
             UINTVAL len2 = Parrot_utf8skip[c];
             UINTVAL count;
 
+            /* partial utf8-character bytes at end of buffer (e.g. split by chunksize) */
             if (i + len2 > len) {
                 res = i + len2 - len;
                 break;


### PR DESCRIPTION
Fixes: https://rt.perl.org/rt3/Public/Bug/Display.html?id=117841

Test with an installed nqp+rakudo is:

perl6 -e 'use Test; for 1..12 -> $x { ok( qqx[perl6 -e "say 1 x $_,q|—|" | cat] ~~ /^1+\—\s*$/, "Test for $_ bytes + utf8 char") for map { 2**$x - 1 }, ^5 }'
