### PR TITLE
only care about strings that are chunk-size long

### DIFF
--- a/config/gen/makefiles/root.in
+++ b/config/gen/makefiles/root.in
@@ -2090,6 +2090,7 @@ src/string/encoding/binary$(O) : \
 
 src/string/encoding/utf8$(O) : \
 	$(PARROT_H_HEADERS) \
+	src/io/io_private.h \
 	src/string/encoding/shared.h \
 	src/string/encoding/utf8.c \
 	src/string/encoding/unicode.h

--- a/src/string/encoding/utf8.c
+++ b/src/string/encoding/utf8.c
@@ -18,6 +18,7 @@ UTF-8 (L<http://www.utf-8.com/>).
 */
 
 #include "parrot/parrot.h"
+#include "../../src/io/io_private.h"
 #include "unicode.h"
 #include "shared.h"
 
@@ -219,7 +220,7 @@ utf8_scan(PARROT_INTERP, ARGMOD(STRING *src))
 
     res = utf8_partial_scan(interp, src->strstart, &bounds);
 
-    if (res == 0 && bounds.bytes != src->bufused)
+    if ((res == 0 || src->bufused < PIO_BUFFER_MIN_SIZE) && bounds.bytes != src->bufused)
         Parrot_ex_throw_from_c_args(interp, NULL, EXCEPTION_MALFORMED_UTF8,
             "Unaligned end in UTF-8 string\n");
 


### PR DESCRIPTION
This fixes the regression for strings shorter than chunk-size. Like the strings used in the tests, with only contain parts of a utf8 byte sequence.
