### PR TITLE
cache iterators in encoding_find_*cclass.

### DIFF
--- a/src/string/encoding/shared.c
+++ b/src/string/encoding/shared.c
@@ -605,8 +605,19 @@ encoding_find_cclass(PARROT_INTERP, INTVAL flags, ARGIN(const STRING *src),
     UINTVAL     codepoint;
     UINTVAL     end = offset + count;
 
-    STRING_ITER_INIT(interp, &iter);
-    STRING_iter_skip(interp, src, &iter, offset);
+    static UINTVAL last_char_offset;
+    static String_iter cached_iter;
+    static STRING *last_string = 0;
+
+    if (last_string == src && offset > last_char_offset) {
+        iter = cached_iter;
+        STRING_iter_skip(interp, src, &iter, offset - last_char_offset);
+    } else if (last_string == src && offset == last_char_offset) {
+        iter = cached_iter;
+    } else {
+        STRING_ITER_INIT(interp, &iter);
+        STRING_iter_skip(interp, src, &iter, offset);
+    }
 
     end = src->strlen < end ? src->strlen : end;
 
@@ -614,15 +625,22 @@ encoding_find_cclass(PARROT_INTERP, INTVAL flags, ARGIN(const STRING *src),
         codepoint = STRING_iter_get_and_advance(interp, src, &iter);
         if (codepoint >= 256) {
             if (u_iscclass(interp, codepoint, flags))
-                    return iter.charpos - 1;
+                goto return_and_cache;
         }
         else {
             if (Parrot_iso_8859_1_typetable[codepoint] & flags)
-                return iter.charpos - 1;
+                goto return_and_cache;
         }
     }
 
     return end;
+return_and_cache:
+    if (iter.charpos > 128) {
+        last_char_offset = iter.charpos;
+        cached_iter = iter;
+        last_string = src;
+    }
+    return iter.charpos - 1;
 }
 
 
@@ -648,15 +666,25 @@ encoding_find_not_cclass(PARROT_INTERP, INTVAL flags, ARGIN(const STRING *src),
     UINTVAL     end = offset + count;
     int         bit;
 
+    static UINTVAL last_char_offset;
+    static String_iter cached_iter;
+    static STRING *last_string = 0;
+
     if (offset > src->strlen) {
         /* XXX: Throw in this case? */
         return offset + count;
     }
 
-    STRING_ITER_INIT(interp, &iter);
-
-    if (offset)
-        STRING_iter_skip(interp, src, &iter, offset);
+    if (last_string == src && offset > last_char_offset) {
+        iter = cached_iter;
+        STRING_iter_skip(interp, src, &iter, offset - last_char_offset);
+    } else if (last_string == src && offset == last_char_offset) {
+        iter = cached_iter;
+    } else {
+        STRING_ITER_INIT(interp, &iter);
+        if (offset)
+            STRING_iter_skip(interp, src, &iter, offset);
+    }
 
     end = src->strlen < end ? src->strlen : end;
 
@@ -669,16 +697,23 @@ encoding_find_not_cclass(PARROT_INTERP, INTVAL flags, ARGIN(const STRING *src),
             for (bit = enum_cclass_uppercase;
                     bit <= enum_cclass_word ; bit <<= 1) {
                 if ((bit & flags) && !u_iscclass(interp, codepoint, bit))
-                    return iter.charpos - 1;
+                    goto return_and_cache;
             }
         }
         else {
             if (!(Parrot_iso_8859_1_typetable[codepoint] & flags))
-                return iter.charpos - 1;
+                goto return_and_cache;
         }
     }
 
     return end;
+return_and_cache:
+    if (iter.charpos > 128) {
+        last_char_offset = iter.charpos;
+        cached_iter = iter;
+        last_string = src;
+    }
+    return iter.charpos - 1;
 }
 
 


### PR DESCRIPTION
encoding_find_cclass and encoding_find_notcclass can now cache an iterator between calls, because there is at least one usage of the pattern "scan a whole string for newlines" in rakudo.

for utf8 files, like Actions.nqp and Grammar.nqp, it used to take 5s and 2s respectively, now takes 2.4s and 0.9s respectively after the patch.

it passes all the parrot tests and (when applied to RELEASE_5_9_0) compiles nqp and rakudo no-problem.
