### PR TITLE
Fix use of native_pcc_method_t

### DIFF
--- a/include/parrot/nci.h
+++ b/include/parrot/nci.h
@@ -15,7 +15,7 @@
 
 typedef PMC *(*nci_fb_func_t)(PARROT_INTERP, PMC *user_data, PMC *signature);
 typedef void (*nci_thunk_t)(PARROT_INTERP, PMC *, PMC *);
-typedef void (*native_pcc_method_t)(PARROT_INTERP);
+typedef void (*native_pcc_method_t)(PARROT_INTERP, PMC *);
 
 void Parrot_nci_load_core_thunks(PARROT_INTERP);
 void Parrot_nci_load_extra_thunks(PARROT_INTERP);

--- a/src/pmc/nativepccmethod.pmc
+++ b/src/pmc/nativepccmethod.pmc
@@ -117,7 +117,7 @@ Call the function pointer.
                     "attempt to call NULL native function");
 
         fptr = (native_pcc_method_t)D2FPTR(func);
-        fptr(INTERP);
+        fptr(INTERP, SELF);
 
         /*
          * If this function was tailcalled, the return result


### PR DESCRIPTION
Native pcc methods always take two arguments, INTERP and SELF, so they
must be called with two arguments.
