### PR TITLE
[lib] using Pod::Checker to check pod

### DIFF
--- a/lib/Parrot/Test/Pod/Utils.pm
+++ b/lib/Parrot/Test/Pod/Utils.pm
@@ -2,7 +2,8 @@
 package Parrot::Test::Pod::Utils;
 use strict;
 use warnings;
-use Pod::Simple;
+use Pod::Checker;
+use Capture::Tiny 'capture';
 use Pod::Simple::PullParser;
 our (@ISA, @EXPORT_OK);
 @ISA       = qw( Exporter );
@@ -11,15 +12,16 @@ our (@ISA, @EXPORT_OK);
     empty_description
 );
 
-# Pulled from Test::Pod
 sub file_pod_ok {
     my $file    = shift;
-    my $checker = Pod::Simple->new;
+    my $checker = Pod::Checker->new;
 
-    $checker->output_string( \my $trash );      # Ignore any output
-    $checker->parse_file($file);
+    # ignore output; we just want to know if we have warnings/errors
+    my $trash = capture {
+        $checker->parse_from_file($file);
+    };
 
-    return !$checker->any_errata_seen;
+    return !$checker->num_errors;
 }
 
 sub empty_description {


### PR DESCRIPTION
Pod::Simple was missing many warnings and errors and thus has been replaced
by Pod::Checker.  This is sensible, since the advice given by the
`pod_syntax.t` test when errors occur is that one should use `podchecker` to
investigate errors in detail, thus we should be using Pod::Checker
internally to begin with.

My only issue with this patch is that I've added a dependency on `Capture::Tiny` in order to ignore the output from `Pod::Checker`; I hope this is OK.

Comments welcome.
