### PR TITLE
[codingstd] removing exceptions for SVN Id tags

### DIFF
--- a/t/codingstd/gmt_utc.t
+++ b/t/codingstd/gmt_utc.t
@@ -42,9 +42,6 @@ my @failures;
 foreach my $file (@files) {
     my $buf = $DIST->slurp($file);
 
-    # trim out SVN Id line
-    $buf =~ s{\$Id:.*}{}g;
-
     # if we have a timezone, check to see if it is GMT/UTC
     push @failures => "$file\n"
         if $buf =~ m{

--- a/t/codingstd/linelength.t
+++ b/t/codingstd/linelength.t
@@ -75,7 +75,6 @@ sub info_for_first_long_line {
         chomp $line;
         $line =~ s/\t/' ' x (1 + length($`) % 8)/eg;  # expand \t
         next if $line =~ m/https?:\/\//;              # skip long web addresses
-        next if $line =~ m/\$Id:/;
         next if $line =~ m/CONST_STRING\(/;
 
         return sprintf '%s:%d: %d cols', $file, $., length($line)

--- a/t/codingstd/pdd_format.t
+++ b/t/codingstd/pdd_format.t
@@ -55,7 +55,7 @@ sub check_pdd_formatting {
         if (
             ( length( $lines[$i] ) > 78 )
             and
-            ( $lines[$i] !~ m/^(?:F|L)<|<http|\$Id:\s+/ )
+            ( $lines[$i] !~ m/^(?:F|L)<|<http/ )
         ) {
             push @toolong, ($i + 1);
         }


### PR DESCRIPTION
Subversion is no longer used in this project and thus the exceptions for the
svn Id: tag within the test code can be removed.
