### PR TITLE
[config] warnings for missing declarations or prototypes now errors

### DIFF
--- a/config/auto/warnings.pm
+++ b/config/auto/warnings.pm
@@ -141,7 +141,7 @@ sub _init {
         -Wjump-misses-init
         -Wlogical-op
         -Werror=missing-braces
-        -Wmissing-declarations
+        -Werror=missing-declarations
         -Wno-missing-format-attribute
         -Wmissing-include-dirs
         -Wmultichar
@@ -166,7 +166,7 @@ sub _init {
         -Wc++-compat
         -Werror=declaration-after-statement
         -Werror=implicit-function-declaration
-        -Wmissing-prototypes
+        -Werror=missing-prototypes
         -Werror=nested-externs
         -Werror=old-style-definition
         -Werror=strict-prototypes


### PR DESCRIPTION
Parrot builds successfully with these warnings elevated to errors.

This should close GH #734.
