### PR TITLE
[config] Correcting debug message text in warnings.pm

### DIFF
--- a/config/auto/warnings.pm
+++ b/config/auto/warnings.pm
@@ -420,7 +420,7 @@ sub valid_warning {
     # This should be using a temp file name.
     my $output_file = 'test.cco';
 
-    $conf->debug("trying attribute '$warning'\n");
+    $conf->debug("trying warning '$warning'\n");
 
     my $cc = $conf->data->get('cc');
     $conf->cc_gen('config/auto/warnings/test_c.in');


### PR DESCRIPTION
What looks like a copy-paste error meant that a debug message from
`config/auto/warnings.pm` was mentioning attributes instead of warnings.
This change corrects this issue.
