### PR TITLE
[tools] correcting `rm_f` command in `make_cover.pl`

### DIFF
--- a/tools/dev/make_cover.pl
+++ b/tools/dev/make_cover.pl
@@ -43,7 +43,7 @@ for my $dir (@ARGV) {
 
     for my $path (glob("$dir/*.c")) {
         # Remove old gcov files
-        my $rm_f = $PConfig{'rm_f'};
+        my $rm_f = "$PConfig{'perl'} -MExtUtils::Command -e rm_f";
         system("$rm_f *.gcov");
 
         # gcov must be run from build dir


### PR DESCRIPTION
When removing `.gcov` files, the configured `rm_f` command was used.  This
unfortunately used an unexpanded `make` variable `$(PERL)` and thus was
producing errors such as:

```
sh: 1: PERL: not found
sh: 1: -MExtUtils::Command: not found
```

The fix was to use the configured perl value and the `ExtUtils::Command`
option as would be used within a Makefile.  This change means that what the
code intends to do (delete the `.gcov` file) actually happens and removes
the error from `make cover` output.
