### PR TITLE
use absolute execname when we can in pbc_to_exe

### DIFF
--- a/tools/dev/pbc_to_exe.winxed
+++ b/tools/dev/pbc_to_exe.winxed
@@ -63,15 +63,16 @@ const string C_MAIN = <<:MAIN
 
             char execname[1024];
             size_t execname_size = sizeof(execname);
+            memset(execname, 0, execname_size);
 #if defined(__APPLE__)
             if (_NSGetExecutablePath(execname, &execname_size) != 0)
-                memcpy(execname, argv[0], 1024);
+                memcpy(execname, argv[0], strlen(argv[0]));
 #elif defined(sun) || defined(__sun)
             const char *_execname = getexecname();
             if (_execname)
-                memcpy(execname, _execname, 1024);
+                memcpy(execname, _execname, strlen(_execname));
             else
-                memcpy(execname, argv[0], 1024);
+                memcpy(execname, argv[0], strlen(argv[0]));
 #elif defined(__FreeBSD__)
             int mib[4];
             mib[0] = CTL_KERN;
@@ -80,22 +81,19 @@ const string C_MAIN = <<:MAIN
             mib[3] = -1;
             sysctl(mib, 4, execname, &execname_size, NULL, 0);
 #elif defined(__NetBSD__)
-            memset(execname, 0, execname_size);
             if (readlink("/proc/curproc/exe", execname, execname_size-1) <= 0)
-                memcpy(execname, argv[0], 1024);
+                memcpy(execname, argv[0], strlen(argv[0]));
 #elif defined(__DragonFly__)
-            memset(execname, 0, execname_size);
             if (readlink("/proc/curproc/file", execname, execname_size-1) <= 0)
-                memcpy(execname, argv[0], 1024);
+                memcpy(execname, argv[0], strlen(argv[0]));
 #elif defined(_WIN32)
             if (GetModuleFileName(NULL, execname, (DWORD)execname_size) == 0)
-                memcpy(execname, argv[0], 1024);
+                memcpy(execname, argv[0], strlen(argv[0]));
 #elif defined(__unix__) || defined(__linux__)
-            memset(execname, 0, execname_size);
             if (readlink("/proc/self/exe", execname, execname_size-1) <= 0)
-                memcpy(execname, argv[0], 1024);
+                memcpy(execname, argv[0], strlen(argv[0]));
 #else
-            memcpy(execname, argv[0], 1024);
+            memcpy(execname, argv[0], strlen(argv[0]));
 #endif
 
             GET_INIT_STRUCT(initargs);


### PR DESCRIPTION
Before this patch it used ARGV[0], which only contains a name like 'perl6'
but not the path to the binary, when this binary is executed as 'perl6'
and found in PATH.
Now it will try to resolv the absolute path to the binary for certain
platforms and will fall back to ARGV[0] if that fails or if the platform
is not supported.
