### PR TITLE
include <sys/sysctl.h> for pbc_to_exe on FreeBSD

### DIFF
--- a/tools/dev/pbc_to_exe.winxed
+++ b/tools/dev/pbc_to_exe.winxed
@@ -41,6 +41,9 @@ const string C_HEADER = <<:HEADER
 #ifdef __APPLE__
 #  include <mach-o/dyld.h> /* for _NSGetExecutablePath() */
 #endif
+#ifdef __FreeBSD__
+#  include <sys/sysctl.h>
+#endif
 #include "parrot/api.h"
 
 int Parrot_set_config_hash(Parrot_PMC interp_pmc);


### PR DESCRIPTION
While compiling pbc_to_exe I got errors like
pbc_to_exe.c:1301:22: error: use of undeclared identifier 'CTL_KERN'
(probably after commit 3c00e7e19969971383e50fb58d31ace46a702828)

Including sys/sysctl.h on FreeBSD solves that problem.
