### PR TITLE
Add specific platform encoding functions for FreeBSD, OpenBSD and NetBSD

### DIFF
--- a/src/platform/freebsd/encoding.c
+++ b/src/platform/freebsd/encoding.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2011-2012, Parrot Foundation.
+ */
+
+/*
+
+=head1 NAME
+
+config/gen/platform/freebsd/encoding.c
+
+=head1 DESCRIPTION
+
+Platform C string encoding management
+
+=head2 Functions
+
+=over 4
+
+=cut
+
+*/
+
+#include "parrot/parrot.h"
+
+#include <locale.h>
+#include <langinfo.h>
+
+/* HEADERIZER HFILE: none */
+
+/*
+
+=item C<void Parrot_init_platform_encoding(PARROT_INTERP)>
+
+Set the platform encoding pointer, used for encoding/decoding strings passed to
+the OS, to an appropriate value.
+
+=cut
+
+*/
+
+void
+Parrot_init_platform_encoding(SHIM_INTERP)
+{
+    const char *orig  = setlocale(LC_CTYPE, NULL); /* store original locale */
+    setlocale(LC_CTYPE, "");                       /* set locale to environment specification */
+    {
+        const char *codeset = nl_langinfo(CODESET);
+        if (STREQ(codeset, "UTF-8"))
+            Parrot_platform_encoding_ptr = Parrot_utf8_encoding_ptr;
+        else if (STREQ(codeset, "ISO8859-1"))
+            Parrot_platform_encoding_ptr = Parrot_latin1_encoding_ptr;
+        else if (STREQ(codeset, "US-ASCII"))
+            Parrot_platform_encoding_ptr = Parrot_ascii_encoding_ptr;
+        else {
+            /* Can't use Parrot_warn here, the interpreter is not ready */
+            fprintf(stderr,
+                "Unknown codeset `%s', defaulting to ASCII\n", codeset);
+            Parrot_platform_encoding_ptr = Parrot_ascii_encoding_ptr;
+        }
+    }
+    setlocale(LC_CTYPE, orig); /* restore original locale */
+}
+
+
+/*
+
+=item C<size_t Parrot_str_platform_strlen(PARROT_INTERP, const char *s)>
+
+Get the length of a platform-encoded C string.
+
+=cut
+
+*/
+
+size_t
+Parrot_str_platform_strlen(SHIM_INTERP, const char *s)
+{
+    return strlen(s);
+}
+
+/*
+
+=back
+
+=cut
+
+*/
+
+/*
+ * Local variables:
+ *   c-file-style: "parrot"
+ * End:
+ * vim: expandtab shiftwidth=4 cinoptions='\:2=2' :
+ */

--- a/src/platform/netbsd/encoding.c
+++ b/src/platform/netbsd/encoding.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2011-2012, Parrot Foundation.
+ */
+
+/*
+
+=head1 NAME
+
+config/gen/platform/netbsd/encoding.c
+
+=head1 DESCRIPTION
+
+Platform C string encoding management
+
+=head2 Functions
+
+=over 4
+
+=cut
+
+*/
+
+#include "parrot/parrot.h"
+
+#include <locale.h>
+#include <langinfo.h>
+
+/* HEADERIZER HFILE: none */
+
+/*
+
+=item C<void Parrot_init_platform_encoding(PARROT_INTERP)>
+
+Set the platform encoding pointer, used for encoding/decoding strings passed to
+the OS, to an appropriate value.
+
+=cut
+
+*/
+
+void
+Parrot_init_platform_encoding(SHIM_INTERP)
+{
+    const char *orig  = setlocale(LC_CTYPE, NULL); /* store original locale */
+    setlocale(LC_CTYPE, "");                       /* set locale to environment specification */
+    {
+        const char *codeset = nl_langinfo(CODESET);
+        if (STREQ(codeset, "UTF-8"))
+            Parrot_platform_encoding_ptr = Parrot_utf8_encoding_ptr;
+        else if (STREQ(codeset, "ISO8859-1"))
+            Parrot_platform_encoding_ptr = Parrot_latin1_encoding_ptr;
+        else if (STREQ(codeset, "646"))
+            Parrot_platform_encoding_ptr = Parrot_ascii_encoding_ptr;
+        else {
+            /* Can't use Parrot_warn here, the interpreter is not ready */
+            fprintf(stderr,
+                "Unknown codeset `%s', defaulting to ASCII\n", codeset);
+            Parrot_platform_encoding_ptr = Parrot_ascii_encoding_ptr;
+        }
+    }
+    setlocale(LC_CTYPE, orig); /* restore original locale */
+}
+
+
+/*
+
+=item C<size_t Parrot_str_platform_strlen(PARROT_INTERP, const char *s)>
+
+Get the length of a platform-encoded C string.
+
+=cut
+
+*/
+
+size_t
+Parrot_str_platform_strlen(SHIM_INTERP, const char *s)
+{
+    return strlen(s);
+}
+
+/*
+
+=back
+
+=cut
+
+*/
+
+/*
+ * Local variables:
+ *   c-file-style: "parrot"
+ * End:
+ * vim: expandtab shiftwidth=4 cinoptions='\:2=2' :
+ */

--- a/src/platform/openbsd/encoding.c
+++ b/src/platform/openbsd/encoding.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2011-2012, Parrot Foundation.
+ */
+
+/*
+
+=head1 NAME
+
+config/gen/platform/openbsd/encoding.c
+
+=head1 DESCRIPTION
+
+Platform C string encoding management
+
+=head2 Functions
+
+=over 4
+
+=cut
+
+*/
+
+#include "parrot/parrot.h"
+
+#include <locale.h>
+#include <langinfo.h>
+
+/* HEADERIZER HFILE: none */
+
+/*
+
+=item C<void Parrot_init_platform_encoding(PARROT_INTERP)>
+
+Set the platform encoding pointer, used for encoding/decoding strings passed to
+the OS, to an appropriate value.
+
+=cut
+
+*/
+
+void
+Parrot_init_platform_encoding(SHIM_INTERP)
+{
+    const char *orig  = setlocale(LC_CTYPE, NULL); /* store original locale */
+    setlocale(LC_CTYPE, "");                       /* set locale to environment specification */
+    {
+        const char *codeset = nl_langinfo(CODESET);
+        if (STREQ(codeset, "UTF-8"))
+            Parrot_platform_encoding_ptr = Parrot_utf8_encoding_ptr;
+        else if (STREQ(codeset, "ISO8859-1"))
+            Parrot_platform_encoding_ptr = Parrot_latin1_encoding_ptr;
+        else if (STREQ(codeset, "646"))
+            Parrot_platform_encoding_ptr = Parrot_ascii_encoding_ptr;
+        else {
+            /* Can't use Parrot_warn here, the interpreter is not ready */
+            fprintf(stderr,
+                "Unknown codeset `%s', defaulting to ASCII\n", codeset);
+            Parrot_platform_encoding_ptr = Parrot_ascii_encoding_ptr;
+        }
+    }
+    setlocale(LC_CTYPE, orig); /* restore original locale */
+}
+
+
+/*
+
+=item C<size_t Parrot_str_platform_strlen(PARROT_INTERP, const char *s)>
+
+Get the length of a platform-encoded C string.
+
+=cut
+
+*/
+
+size_t
+Parrot_str_platform_strlen(SHIM_INTERP, const char *s)
+{
+    return strlen(s);
+}
+
+/*
+
+=back
+
+=cut
+
+*/
+
+/*
+ * Local variables:
+ *   c-file-style: "parrot"
+ * End:
+ * vim: expandtab shiftwidth=4 cinoptions='\:2=2' :
+ */


### PR DESCRIPTION
Supports ASCII, UTF-8 and Latin-1 locales;
Uses slightly adjusted version of the linux-specific encoding functions
