### PR TITLE
include unistd.h for system we need it

### DIFF
--- a/tools/dev/pbc_to_exe.winxed
+++ b/tools/dev/pbc_to_exe.winxed
@@ -37,7 +37,9 @@ const string C_HEADER = <<:HEADER
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if defined(__NetBSD__) || defined(__DragonFly__) || defined(__unix__) || defined(__linux__)
 #include <unistd.h> /* for readlink() */
+#endif
 #ifdef __APPLE__
 #  include <mach-o/dyld.h> /* for _NSGetExecutablePath() */
 #endif


### PR DESCRIPTION
My windows box complains about missing unistd.h, and since it is not used on windows we do not need to include it.
