### PR TITLE
export symbol Parrot_io_get_vtable

### DIFF
--- a/include/parrot/io.h
+++ b/include/parrot/io.h
@@ -657,6 +657,7 @@ PARROT_WARN_UNUSED_RESULT
 PIOHANDLE Parrot_io_get_standard_piohandle(PARROT_INTERP, INTVAL idx)
         __attribute__nonnull__(1);
 
+PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 PARROT_CAN_RETURN_NULL
 const IO_VTABLE * Parrot_io_get_vtable(PARROT_INTERP,

--- a/src/io/api.c
+++ b/src/io/api.c
@@ -154,6 +154,7 @@ Parrot_io_allocate_new_vtable(PARROT_INTERP, ARGIN(const char *name))
     return vtable;
 }
 
+PARROT_EXPORT
 PARROT_WARN_UNUSED_RESULT
 PARROT_CAN_RETURN_NULL
 const IO_VTABLE *


### PR DESCRIPTION
Parrot_io_get_vtable is part of the public api so we have to make it available.
