### PR TITLE
AIX7.1 support

### DIFF
--- a/config/auto/stat.pm
+++ b/config/auto/stat.pm
@@ -72,6 +72,20 @@ sub runstep {
 
     $conf->data->set( HAS_STAT_ATIMESPEC => $stat_atimespec );
 
+    my $stat_st_timespec_t = 0;
+
+    $conf->cc_gen('config/auto/stat/test_st_timespec_t_c.in');
+    eval { $conf->cc_build(); };
+    if (!$@) {
+        my $output = eval { $conf->cc_run() };
+        if (!$@ && $output =~ /OK/) {
+            $stat_st_timespec_t = 1;
+        }
+    }
+    $conf->cc_clean();
+
+    $conf->data->set( HAS_STAT_ST_TIMESPEC_T => $stat_st_timespec_t );
+
     return 1;
 }
 

--- a/config/auto/stat/test_st_timespec_t_c.in
+++ b/config/auto/stat/test_st_timespec_t_c.in
@@ -1,0 +1,25 @@
+/*
+Copyright (C) 2015, Parrot Foundation.
+
+check if type st_timespec_t is defined
+
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+int
+main()
+{
+    st_timespec_t timespec = { 0, 0 };
+    printf("OK\n");
+    return EXIT_SUCCESS;
+}
+
+/*
+ * Local variables:
+ *   c-file-style: "parrot"
+ * End:
+ * vim: expandtab shiftwidth=4 cinoptions='\:2=2' :
+ */

--- a/config/init/defaults.pm
+++ b/config/init/defaults.pm
@@ -79,6 +79,10 @@ sub runstep {
 
     my $ccdlflags = $Config{ccdlflags};
     $ccdlflags =~ s/\s*-Wl,-rpath,\S*//g if $conf->options->get('disable-rpath');
+    $ccdlflags =~ s/-Xlink.*perl\.exp// if $Config{osname} eq 'aix';
+
+    my $lddlflags = $Config{lddlflags};
+    $lddlflags =~ s/-Wl,-bI:\$\(PERL_INC\)\/perl\.exp -Wl,-bE:\$\(BASEEXT\)\.exp// if $Config{osname} eq 'aix';
 
     my $build_dir =  abs_path($FindBin::Bin);
 
@@ -139,11 +143,11 @@ sub runstep {
         # Some operating systems (e.g. Darwin) distinguish between shared
         # libraries and modules that can be dynamically loaded.  Flags to tell
         # ld to build a shared library, e.g.  -shared for GNU ld.
-        ld_share_flags => $Config{lddlflags},
+        ld_share_flags => $lddlflags,
 
         # Flags to tell ld to build a dynamically loadable module, e.g.
         # -shared for GNU ld, -bundle -undefined dynamic_lookup on darwin.
-        ld_load_flags => $Config{lddlflags},
+        ld_load_flags => $lddlflags,
 
         libs => $Config{libs},
 

--- a/include/parrot/platform_interface.h
+++ b/include/parrot/platform_interface.h
@@ -165,10 +165,17 @@ typedef struct _Parrot_Stat_Buf {
     INTVAL     block_size;
     INTVAL     blocks;
 
+#ifdef PARROT_HAS_STAT_ST_TIMESPEC_T
+    st_timespec_t create_time;
+    st_timespec_t access_time;
+    st_timespec_t modify_time;
+    st_timespec_t change_time;
+#else
     struct timespec create_time;
     struct timespec access_time;
     struct timespec modify_time;
     struct timespec change_time;
+#endif
 } Parrot_Stat_Buf;
 
 PARROT_EXPORT

--- a/src/platform/generic/file.c
+++ b/src/platform/generic/file.c
@@ -192,7 +192,11 @@ static void
 convert_stat_buf(ARGIN(struct stat *stat_buf), ARGOUT(Parrot_Stat_Buf *buf))
 {
     ASSERT_ARGS(convert_stat_buf)
+#ifdef PARROT_HAS_STAT_ST_TIMESPEC_T
+    static const st_timespec_t zero = { 0, 0 };
+#else
     static const struct timespec zero = { 0, 0 };
+#endif
 
     INTVAL type;
 


### PR DESCRIPTION
This PR adds AIX7.1 support.

Problems building parrot on AIX7.1 are:

1. Struct `stat` has `st_timespec_t` members, not `timespec`
2. The linker options contain unnecessary reference to export files

So this PR modifies the following:

1. Check if `st_timespec_t` is defined. If so, use it instead of `timespec`
2. Remove some linker options that are obstructive to the linking process
