### PR TITLE
fix unix domain sockets

### DIFF
--- a/include/parrot/platform_interface.h
+++ b/include/parrot/platform_interface.h
@@ -104,6 +104,7 @@ INTVAL Parrot_io_internal_async(PARROT_INTERP, ARGMOD(PMC *pmc), INTVAL async);
 
 PMC *Parrot_io_internal_getaddrinfo(PARROT_INTERP, ARGIN(STRING *addr), INTVAL port,
         INTVAL protocol, INTVAL family, INTVAL passive);
+PMC *Parrot_io_internal_getaddrinfo_unix(PARROT_INTERP, ARGIN(STRING *addr));
 INTVAL Parrot_io_internal_addr_match(PARROT_INTERP, ARGIN(PMC *sa), INTVAL family, INTVAL type,
             INTVAL protocol);
 STRING *Parrot_io_internal_getnameinfo(PARROT_INTERP, ARGIN(const void *addr), INTVAL addr_len);

--- a/src/pmc/socket.pmc
+++ b/src/pmc/socket.pmc
@@ -193,8 +193,12 @@ family (integer). If no address family is given, it defaults to IPv4.
         if (!family)
             family = PIO_PF_INET;
 
-        array = Parrot_io_internal_getaddrinfo(INTERP, address, port, PIO_PROTO_TCP,
-                    family, 0);
+        if (family == PIO_PF_UNIX) {
+            array = Parrot_io_internal_getaddrinfo_unix(INTERP, address);
+        } else {
+            array = Parrot_io_internal_getaddrinfo(INTERP, address, port,
+                    PIO_PROTO_TCP, family, 0);
+        }
 
         if (VTABLE_elements(interp, array))
             res = VTABLE_get_pmc_keyed_int(interp, array, 0);


### PR DESCRIPTION
*Initial stab at this: here be dragons!*

It's not currently possible to bind an AF_UNIX socket because `getaddrinfo()`
and `getnameinfo()` don't work with AF_UNIX on all platforms.

This patch does the following:
- Fix `getaddrinfo()` error reporting; it works via `gai_strerror()` rather
  than `errno`.
- Implement more error checking, preventing possible uninitialized reads if
  `getnameinfo()` fails.
- Implement special-cases for `Parrot_io_internal_getaddrinfo()` and
  `Parrot_io_internal_getnameinfo()` in the AF_UNIX case; on platforms
  without `sys/un.h`, these functions will now return an error if the socket
  family is (somehow) AF_UNIX.
- Implement some simple tests for working with Unix sockets.

I couldn't get Parrot compiling with msvc on Windows, so I'm not completely
confident the platform conditional logic is correct.