### PR TITLE
Avoid "Negative repeat count does nothing" warning

### DIFF
--- a/lib/Parrot/Configure.pm
+++ b/lib/Parrot/Configure.pm
@@ -476,10 +476,9 @@ sub _finish_printing_result {
         );
     }
     else {
-        print '.' x (
-            $linelength -
-            ( $argsref->{length_message} + length($result) + 1 )
-        );
+        my $sum = $linelength -
+            ( $argsref->{length_message} + length($result) + 1 );
+        print '.' x $sum if $sum > 0;
     }
     unless ( $argsref->{step_name} =~ m{^inter} && $argsref->{args}->{ask} ) {
         print "$result.";


### PR DESCRIPTION
For inter::shlibs, the sum of the description and the result can, on certain platforms (e.g., FreeBSD-14), exceed the maximum, which causes a warning to be emitted.
```
inter::shlibs -       Determine flags for building shared libraries...Negative repeat count does nothing at lib/Parrot/Configure.pm line 481.
-DPIC -fPIC.
```
In this case, let's just let the line overflow a little, as that's less surprising than the warning.